### PR TITLE
Embed version info in app & improve release process docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,23 +66,44 @@ dotnet run --project SheetMusicViewer.Desktop
 
 The project uses GitHub Actions for CI/CD. To create a new release:
 
-1. **Tag the commit** with a version number starting with `v`:
+1. **Ensure you're on the `main` branch** with all changes merged:
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+
+2. **Tag the commit** with a version number starting with `v`:
    ```bash
    git tag v1.0.0
    git push origin v1.0.0
    ```
 
-2. **GitHub Actions will automatically**:
+3. **GitHub Actions will automatically**:
    - Build the application on Windows, macOS, and Linux
    - Run all tests on each platform
    - Create self-contained, single-file executables
-   - Create a GitHub Release with:
-     - `SheetMusicViewer-win-x64.zip`
-     - `SheetMusicViewer-linux-x64.tar.gz`
-     - `SheetMusicViewer-osx-arm64.tar.gz`
-   - Auto-generate release notes from commit history
+   - Create a GitHub Release with downloadable binaries
+   - Embed the version number in the application (visible in **Menu ? About**)
 
-3. **Version format**: Use semantic versioning (e.g., `v1.0.0`, `v1.2.3`, `v2.0.0-beta`)
+4. **Version format**: Use semantic versioning (e.g., `v1.0.0`, `v1.2.3`, `v2.0.0-beta`)
+
+> **Note**: Releases should always be created from `main` to ensure they contain stable, reviewed code.
+
+### Listing Prior Releases
+
+```bash
+# List all version tags
+git tag -l "v*"
+
+# List tags with dates (most recent first)
+git tag -l "v*" --sort=-version:refname
+
+# Show details of a specific release
+git show v1.0.0
+
+# View releases on GitHub
+# https://github.com/calvinhsia/SheetMusicViewer/releases
+```
 
 ### CI/CD Pipeline
 

--- a/SheetMusicViewer.Desktop/PdfViewerWindow.axaml.cs
+++ b/SheetMusicViewer.Desktop/PdfViewerWindow.axaml.cs
@@ -1212,19 +1212,22 @@ public partial class PdfViewerWindow : Window, INotifyPropertyChanged
     private void BtnAbout_Click(object? sender, RoutedEventArgs e)
     {
         var aboutMessage = $"{MyAppName}\n\n" +
+                          $"Version: {BuildInfo.Version}\n" +
                           $"Branch: {BuildInfo.GitBranch}\n" +
+                          $"Commit: {BuildInfo.GitCommit}\n" +
                           $"Build Time: {BuildInfo.BuildTime}\n\n" +
                           $"Cross-platform PDF sheet music viewer\n" +
                           $"Built with Avalonia UI and PDFtoImage\n\n" +
                           $".NET Runtime: {Environment.Version}";
         
-        // Simple dialog using a window
+        // Simple dialog using a window with Esc key support
         var dialog = new Window
         {
             Title = "About",
-            Width = 350,
-            Height = 250,
+            Width = 380,
+            Height = 280,
             WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = false,
             Content = new TextBlock
             {
                 Text = aboutMessage,
@@ -1232,6 +1235,17 @@ public partial class PdfViewerWindow : Window, INotifyPropertyChanged
                 TextWrapping = TextWrapping.Wrap
             }
         };
+        
+        // Allow Esc key to close the dialog
+        dialog.KeyDown += (s, args) =>
+        {
+            if (args.Key == Key.Escape)
+            {
+                dialog.Close();
+                args.Handled = true;
+            }
+        };
+        
         dialog.ShowDialog(this);
     }
     

--- a/SheetMusicViewer.Desktop/SheetMusicViewer.Desktop.csproj
+++ b/SheetMusicViewer.Desktop/SheetMusicViewer.Desktop.csproj
@@ -69,13 +69,26 @@
 
   <!-- Generate BuildInfo in obj folder (not source controlled) -->
   <Target Name="GenerateBuildInfo" BeforeTargets="BeforeCompile">
-    <!-- Try git from PATH first -->
-    <Exec Command="git rev-parse --abbrev-ref HEAD" ConsoleToMSBuild="true" IgnoreExitCode="true" StandardErrorImportance="low" IgnoreStandardErrorWarningFormat="true">
+    <!-- Try git from PATH first for branch name -->
+    <Exec Command="git rev-parse --abbrev-ref HEAD" ConsoleToMSBuild="true" IgnoreExitCode="true" StandardErrorImportance="low" IgnoreStandardErrorWarningFormat="true" StandardOutputImportance="low">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitBranchName" />
+      <Output TaskParameter="ExitCode" PropertyName="GitBranchExitCode" />
+    </Exec>
+    
+    <!-- Get git commit for version info -->
+    <Exec Command="git rev-parse --short HEAD" ConsoleToMSBuild="true" IgnoreExitCode="true" StandardErrorImportance="low" IgnoreStandardErrorWarningFormat="true" StandardOutputImportance="low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitShort" />
+      <Output TaskParameter="ExitCode" PropertyName="GitCommitExitCode" />
+    </Exec>
+    
+    <!-- Get git tag (version) - uses describe to find most recent tag -->
+    <Exec Command="git describe --tags --abbrev=0" ConsoleToMSBuild="true" IgnoreExitCode="true" StandardErrorImportance="low" IgnoreStandardErrorWarningFormat="true" StandardOutputImportance="low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitTag" />
+      <Output TaskParameter="ExitCode" PropertyName="GitTagExitCode" />
     </Exec>
     
     <!-- Fallback: Try Visual Studio's bundled git if PATH git failed -->
-    <Exec Command="&quot;$(DevEnvDir)CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\cmd\git.exe&quot; rev-parse --abbrev-ref HEAD" ConsoleToMSBuild="true" IgnoreExitCode="true" StandardErrorImportance="low" IgnoreStandardErrorWarningFormat="true" Condition="'$(GitBranchName)' == '' OR $(GitBranchName.Contains('not recognized')) OR $(GitBranchName.Contains('is not'))">
+    <Exec Command="&quot;$(DevEnvDir)CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\cmd\git.exe&quot; rev-parse --abbrev-ref HEAD" ConsoleToMSBuild="true" IgnoreExitCode="true" StandardErrorImportance="low" IgnoreStandardErrorWarningFormat="true" Condition="'$(GitBranchExitCode)' != '0'">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitBranchName" />
     </Exec>
     
@@ -85,7 +98,8 @@
     </GetPacificTime>
     
     <PropertyGroup>
-      <!-- Reset GitBranchName if it contains error messages (git not available) -->
+      <!-- Reset GitBranchName if git command failed -->
+      <GitBranchName Condition="'$(GitBranchExitCode)' != '0'">unknown</GitBranchName>
       <GitBranchName Condition="$(GitBranchName.Contains('not recognized'))">unknown</GitBranchName>
       <GitBranchName Condition="$(GitBranchName.Contains('is not'))">unknown</GitBranchName>
       <GitBranchName Condition="$(GitBranchName.Contains('fatal:'))">unknown</GitBranchName>
@@ -94,14 +108,28 @@
       <GitBranchName Condition="'$(GitBranchName)' == 'HEAD' AND '$(BUILD_SOURCEBRANCHNAME)' != ''">$(BUILD_SOURCEBRANCHNAME)</GitBranchName>
       <GitBranchName Condition="'$(GitBranchName)' == 'HEAD'">detached-HEAD</GitBranchName>
       <GitBranchName Condition="'$(GitBranchName)' == ''">unknown</GitBranchName>
+      <!-- Reset GitCommitShort if git command failed -->
+      <GitCommitShort Condition="'$(GitCommitExitCode)' != '0'">unknown</GitCommitShort>
+      <GitCommitShort Condition="$(GitCommitShort.Contains('not recognized'))">unknown</GitCommitShort>
+      <GitCommitShort Condition="$(GitCommitShort.Contains('is not'))">unknown</GitCommitShort>
+      <GitCommitShort Condition="$(GitCommitShort.Contains('fatal:'))">unknown</GitCommitShort>
+      <GitCommitShort Condition="'$(GitCommitShort)' == ''">unknown</GitCommitShort>
+      <!-- Reset GitTag if git command failed - strip leading 'v' if present -->
+      <GitTag Condition="'$(GitTagExitCode)' != '0'">0.0.0-dev</GitTag>
+      <GitTag Condition="$(GitTag.Contains('not recognized'))">0.0.0-dev</GitTag>
+      <GitTag Condition="$(GitTag.Contains('is not'))">0.0.0-dev</GitTag>
+      <GitTag Condition="$(GitTag.Contains('fatal:'))">0.0.0-dev</GitTag>
+      <GitTag Condition="'$(GitTag)' == ''">0.0.0-dev</GitTag>
+      <!-- Strip leading 'v' from tag for version -->
+      <GitVersion>$(GitTag.TrimStart('v'))</GitVersion>
       <BuildInfoPath>$(IntermediateOutputPath)BuildInfo.g.cs</BuildInfoPath>
     </PropertyGroup>
-    <WriteLinesToFile File="$(BuildInfoPath)" Overwrite="true" Lines="// &lt;auto-generated/&gt;&#xD;&#xA;namespace SheetMusicViewer.Desktop&#xD;&#xA;{&#xD;&#xA;    public static class BuildInfo&#xD;&#xA;    {&#xD;&#xA;        public const string BuildTime = &quot;$(BuildTimestamp)&quot;%3B&#xD;&#xA;        public const string GitBranch = &quot;$(GitBranchName)&quot;%3B&#xD;&#xA;    }&#xD;&#xA;}" />
+    <WriteLinesToFile File="$(BuildInfoPath)" Overwrite="true" Lines="// &lt;auto-generated/&gt;&#xD;&#xA;namespace SheetMusicViewer.Desktop&#xD;&#xA;{&#xD;&#xA;    public static class BuildInfo&#xD;&#xA;    {&#xD;&#xA;        public const string Version = &quot;$(GitVersion)&quot;%3B&#xD;&#xA;        public const string BuildTime = &quot;$(BuildTimestamp)&quot;%3B&#xD;&#xA;        public const string GitBranch = &quot;$(GitBranchName)&quot;%3B&#xD;&#xA;        public const string GitCommit = &quot;$(GitCommitShort)&quot;%3B&#xD;&#xA;    }&#xD;&#xA;}" />
     <ItemGroup>
       <Compile Include="$(BuildInfoPath)" />
       <FileWrites Include="$(BuildInfoPath)" />
     </ItemGroup>
-    <Message Text="Generated BuildInfo: Branch=$(GitBranchName), Time=$(BuildTimestamp)" Importance="high" />
+    <Message Text="Generated BuildInfo: Version=$(GitVersion), Branch=$(GitBranchName), Commit=$(GitCommitShort), Time=$(BuildTimestamp)" Importance="high" />
   </Target>
   
   <ItemGroup>


### PR DESCRIPTION
- About dialog now shows version, branch, commit, and build time from generated BuildInfo.
- Build process extracts git tag (version), branch, and commit hash, with robust fallbacks for CI or missing git.
- README release instructions clarified: require main branch, explain versioning, and add section on listing prior releases.
- About dialog usability improved: larger, non-resizable, and supports Esc to close.