### PR TITLE
Expand CI triggers to all branches for push and PR events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main, tests, develop, extractToLib ]
+    branches: [ '**' ]  # Trigger on push to any branch
     tags:
       - 'v*'
   pull_request:
-    branches: [ main, tests ]
+    branches: [ '**' ]  # Trigger on PR to any branch
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Updated CI/CD pipeline config to trigger on pushes and pull requests to any branch by changing branch patterns to '**'. Previously, the workflow only ran on a limited set of branches. Tag triggers remain unchanged.