### PR TITLE
Fix pianoscroll, note ties, and MIDI output synchronization

### DIFF
--- a/AvaloniaTests/Tests/MxlVisualizationManualTests.cs
+++ b/AvaloniaTests/Tests/MxlVisualizationManualTests.cs
@@ -211,8 +211,10 @@ public class MxlVisualizationManualTests : TestBase
     {
         if (!OperatingSystem.IsWindows())
             Assert.Inconclusive("MIDI playback requires Windows (winmm.dll).");
-        var score = ParseMxl(AdhocMxlPath);
-        await ShowVerticalPianoRollWindowAsync(AdhocMxlPath, score, startMeasure:45, syncDiagnostics: true);
+        var pathToMxl = Path.Combine(GetSheetMusicFolder(), @"Pop\SangahNoonaSingles\Happy Birthday to You! - F Major - MK0108772.mxl");
+
+        var score = ParseMxl(pathToMxl);
+        await ShowVerticalPianoRollWindowAsync(pathToMxl, score, startMeasure: 0, syncDiagnostics: true);
     }
 
     /// <summary>
@@ -317,26 +319,26 @@ public class MxlVisualizationManualTests : TestBase
         {
             var score = pattern switch
             {
-                "ChromaticFullRange"      => MusicGenerator.ChromaticFullRange(),
-                "ChromaticWithOctave"     => MusicGenerator.ChromaticWithOctave(),
-                "MajorScales"             => MusicGenerator.MajorScales(),
-                "WholeToneScales"         => MusicGenerator.WholeToneScales(),
-                "MinorArpeggios"          => MusicGenerator.MinorArpeggios(),
-                "AlbertiBassAndMelody"    => MusicGenerator.AlbertiBassAndMelody(),
-                "Polyrhythm"              => MusicGenerator.Polyrhythm(),
+                "ChromaticFullRange" => MusicGenerator.ChromaticFullRange(),
+                "ChromaticWithOctave" => MusicGenerator.ChromaticWithOctave(),
+                "MajorScales" => MusicGenerator.MajorScales(),
+                "WholeToneScales" => MusicGenerator.WholeToneScales(),
+                "MinorArpeggios" => MusicGenerator.MinorArpeggios(),
+                "AlbertiBassAndMelody" => MusicGenerator.AlbertiBassAndMelody(),
+                "Polyrhythm" => MusicGenerator.Polyrhythm(),
                 "PolyrhythmTonicDominant" => MusicGenerator.PolyrhythmTonicDominant(),
-                "BrownianWalk"            => MusicGenerator.BrownianWalk(),
-                "Pop"                     => MusicGenerator.StylePop(),
-                "Jazz"                    => MusicGenerator.StyleJazz(),
-                "RnB"                     => MusicGenerator.StyleRnB(),
-                "Rock"                    => MusicGenerator.StyleRock(),
-                "HipHop"                  => MusicGenerator.StyleHipHop(),
-                "Latin"                   => MusicGenerator.StyleLatin(),
-                "Tango"                   => MusicGenerator.StyleTango(),
-                "BossaNova"               => MusicGenerator.StyleBossaNova(),
-                "Gospel"                  => MusicGenerator.StyleGospel(),
-                "Country"                 => MusicGenerator.StyleCountry(),
-                "Ragtime"                 => MusicGenerator.StyleRagtime(),
+                "BrownianWalk" => MusicGenerator.BrownianWalk(),
+                "Pop" => MusicGenerator.StylePop(),
+                "Jazz" => MusicGenerator.StyleJazz(),
+                "RnB" => MusicGenerator.StyleRnB(),
+                "Rock" => MusicGenerator.StyleRock(),
+                "HipHop" => MusicGenerator.StyleHipHop(),
+                "Latin" => MusicGenerator.StyleLatin(),
+                "Tango" => MusicGenerator.StyleTango(),
+                "BossaNova" => MusicGenerator.StyleBossaNova(),
+                "Gospel" => MusicGenerator.StyleGospel(),
+                "Country" => MusicGenerator.StyleCountry(),
+                "Ragtime" => MusicGenerator.StyleRagtime(),
                 _ => throw new ArgumentException($"Unknown pattern '{pattern}'.")
             };
 
@@ -425,7 +427,7 @@ public class MxlVisualizationManualTests : TestBase
         {
             int staff1Notes = p.Measures.Sum(m => m.Notes.Count(n => !n.IsRest && n.Staff == 1));
             int staff2Notes = p.Measures.Sum(m => m.Notes.Count(n => !n.IsRest && n.Staff == 2));
-            int otherNotes  = p.Measures.Sum(m => m.Notes.Count(n => !n.IsRest && n.Staff > 2));
+            int otherNotes = p.Measures.Sum(m => m.Notes.Count(n => !n.IsRest && n.Staff > 2));
             sb.AppendLine($"  [{p.PartId}] idx={p.PartIndex} {p.InstrumentName,-28}  MIDI={p.MidiProgram,3}  " +
                           $"Measures={p.Measures.Count,4}  Notes={p.NoteCount,5}  Rests={p.RestCount,4}  " +
                           $"Staff1={staff1Notes}  Staff2={staff2Notes}  StaffOther={otherNotes}");
@@ -744,11 +746,11 @@ public class MxlVisualizationManualTests : TestBase
         }
         LogMessage(diagSbP.ToString());
 
-        var canvas       = new PlayablePianoRollCanvas(score);
+        var canvas = new PlayablePianoRollCanvas(score);
         var scrollViewer = new ScrollViewer
         {
             HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
-            VerticalScrollBarVisibility   = ScrollBarVisibility.Auto,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
             Content = canvas
         };
 
@@ -769,9 +771,10 @@ public class MxlVisualizationManualTests : TestBase
 
         var bpmSlider = new Slider
         {
-            Minimum = 40, Maximum = 300,
-            Value   = score.DefaultBpm,
-            Width   = 180,
+            Minimum = 40,
+            Maximum = 300,
+            Value = score.DefaultBpm,
+            Width = 180,
             VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
             [ToolTip.TipProperty] = "Tempo (BPM)"
         };
@@ -788,15 +791,16 @@ public class MxlVisualizationManualTests : TestBase
                 bpmLabel.Text = $"{bpmSlider.Value:F0} BPM";
         };
 
-        var playBtn = new Button { Content = "-  Play",  Margin = new Thickness(4), Padding = new Thickness(8, 2) };
-        var stopBtn = new Button { Content = "-  Stop",  Margin = new Thickness(4), Padding = new Thickness(8, 2), IsEnabled = false };
+        var playBtn = new Button { Content = "-  Play", Margin = new Thickness(4), Padding = new Thickness(8, 2) };
+        var stopBtn = new Button { Content = "-  Stop", Margin = new Thickness(4), Padding = new Thickness(8, 2), IsEnabled = false };
 
         int totalMeasuresH = score.Parts.Max(p => p.Measures.Count);
-        var measureSlider  = new Slider
+        var measureSlider = new Slider
         {
-            Minimum = 1, Maximum = Math.Max(1, totalMeasuresH),
-            Value   = 1,
-            Width   = 260,
+            Minimum = 1,
+            Maximum = Math.Max(1, totalMeasuresH),
+            Value = 1,
+            Width = 260,
             VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
             [ToolTip.TipProperty] = "Jump to measure (stop first)"
         };
@@ -863,10 +867,10 @@ public class MxlVisualizationManualTests : TestBase
                 : Path.Combine(AppContext.BaseDirectory, "Soundfonts", "VintageDreamsWaves.sf2");
             player = new MxlMidiPlayer(score)
             {
-                Bpm           = bpmSlider.Value,
-                StartMeasure  = (int)measureSlider.Value,
-                LogNotes      = logNotesChk.IsChecked == true,
-                Backend       = fluidSynthChk.IsChecked == true ? MidiBackendKind.FluidSynth : MidiBackendKind.Winmm,
+                Bpm = bpmSlider.Value,
+                StartMeasure = (int)measureSlider.Value,
+                LogNotes = logNotesChk.IsChecked == true,
+                Backend = fluidSynthChk.IsChecked == true ? MidiBackendKind.FluidSynth : MidiBackendKind.Winmm,
                 SoundfontPath = sfPathH,
             };
 
@@ -885,7 +889,7 @@ public class MxlVisualizationManualTests : TestBase
 
             playBtn.IsEnabled = false;
             stopBtn.IsEnabled = true;
-            statusBlock.Text  = "Playing -  ...";
+            statusBlock.Text = "Playing -  ...";
             player.Start();
         };
 
@@ -943,11 +947,11 @@ public class MxlVisualizationManualTests : TestBase
         if (!sf2Files.Contains(defaultSf) && sf2Files.Count > 0) defaultSf = sf2Files[0];
         var combo = new ComboBox
         {
-            ItemsSource  = sf2Files,
+            ItemsSource = sf2Files,
             SelectedItem = sf2Files.Contains(defaultSf) ? defaultSf : sf2Files.FirstOrDefault(),
-            Width        = 220,
+            Width = 220,
             VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            Margin  = new Thickness(4, 0),
+            Margin = new Thickness(4, 0),
             IsEnabled = fluidSynthChk.IsChecked == true,
             [ToolTip.TipProperty] = "Soundfont (.sf2) - VintageDreams is fast; YDP-GrandPiano sounds best but needs polyphony-32"
         };
@@ -975,9 +979,9 @@ public class MxlVisualizationManualTests : TestBase
         var seekMeasure = score.Parts.Count > 0
             ? score.Parts[0].Measures.FirstOrDefault(m => m.Number >= startMeasure)
             : null;
-        double seekMs   = seekMeasure?.GlobalOnsetMs ?? 0.0;
+        double seekMs = seekMeasure?.GlobalOnsetMs ?? 0.0;
         var lastMeasure = score.Parts.Count > 0 ? score.Parts[0].Measures.LastOrDefault() : null;
-        double totalMs  = lastMeasure != null
+        double totalMs = lastMeasure != null
             ? (lastMeasure.GlobalOnsetMs - seekMs) * 1.0 + 8_000   // +8 s for last measure's notes
             : 60_000;
         int timeoutMs = (int)Math.Clamp(totalMs + 30_000, 60_000, 600_000);  // min 60 s, max 10 min
@@ -1064,24 +1068,24 @@ public class MxlVisualizationManualTests : TestBase
 /// </summary>
 internal class PianoRollCanvas : Control
 {
-    protected static readonly int MinMidi      = 21;
-    protected static readonly int MaxMidi      = 108;
-    protected static readonly int KeyH         = 5;
-    protected static readonly int MeasureW     = 80;
-    protected static readonly int YAxisW       = 32;
-    private   static readonly int[] BlackKeys  = { 1, 3, 6, 8, 10 };
+    protected static readonly int MinMidi = 21;
+    protected static readonly int MaxMidi = 108;
+    protected static readonly int KeyH = 5;
+    protected static readonly int MeasureW = 80;
+    protected static readonly int YAxisW = 32;
+    private static readonly int[] BlackKeys = { 1, 3, 6, 8, 10 };
 
     protected readonly MxlScore _score;
-    protected readonly int    _totalMeasures;
+    protected readonly int _totalMeasures;
     protected readonly double _canvasW;
     protected readonly double _canvasH;
 
     public PianoRollCanvas(MxlScore score)
     {
-        _score         = score;
+        _score = score;
         _totalMeasures = score.Parts.Max(p => p.Measures.Count);
-        _canvasW       = YAxisW + _totalMeasures * MeasureW;
-        _canvasH       = (MaxMidi - MinMidi + 1) * KeyH;
+        _canvasW = YAxisW + _totalMeasures * MeasureW;
+        _canvasH = (MaxMidi - MinMidi + 1) * KeyH;
     }
 
     protected override Size MeasureOverride(Size _) => new(_canvasW, _canvasH);
@@ -1094,7 +1098,7 @@ internal class PianoRollCanvas : Control
         if (parts.Count == 0) return YAxisW;
         foreach (var measure in parts[0].Measures)
         {
-            int divs  = Math.Max(1, measure.Divisions);
+            int divs = Math.Max(1, measure.Divisions);
             long mEnd = measure.GlobalOnsetDivisions + divs * 4;  // approx measure end
             if (globalDivs >= measure.GlobalOnsetDivisions && globalDivs < mEnd)
             {
@@ -1110,13 +1114,13 @@ internal class PianoRollCanvas : Control
 
     public override void Render(DrawingContext ctx)
     {
-        var bg        = new SolidColorBrush(Color.FromRgb(28, 28, 28));
+        var bg = new SolidColorBrush(Color.FromRgb(28, 28, 28));
         var blackKeyB = new SolidColorBrush(Color.FromRgb(48, 48, 48));
-        var gridPen   = new Pen(new SolidColorBrush(Color.FromRgb(55, 55, 55)), 0.5);
+        var gridPen = new Pen(new SolidColorBrush(Color.FromRgb(55, 55, 55)), 0.5);
         var octavePen = new Pen(new SolidColorBrush(Color.FromRgb(90, 90, 90)), 0.8);
-        var measurePen= new Pen(new SolidColorBrush(Color.FromRgb(65, 65, 65)), 0.5);
-        var labelBrush= new SolidColorBrush(Color.FromRgb(140, 140, 140));
-        var tf        = new Typeface("Consolas");
+        var measurePen = new Pen(new SolidColorBrush(Color.FromRgb(65, 65, 65)), 0.5);
+        var labelBrush = new SolidColorBrush(Color.FromRgb(140, 140, 140));
+        var tf = new Typeface("Consolas");
 
         ctx.FillRectangle(bg, new Rect(0, 0, _canvasW, _canvasH));
 
@@ -1158,32 +1162,32 @@ internal class PianoRollCanvas : Control
         // Staff 2 (left hand)  - bottom half of the row (blue)
         var staff1Brush = new SolidColorBrush(Color.FromArgb(220, 64, 192, 87));   // green
         var staff2Brush = new SolidColorBrush(Color.FromArgb(220, 88, 130, 226));  // blue
-        var otherBrush  = new SolidColorBrush(Color.FromArgb(200, 200, 180, 80));  // amber
+        var otherBrush = new SolidColorBrush(Color.FromArgb(200, 200, 180, 80));  // amber
 
         int halfH = Math.Max(1, (KeyH - 2) / 2);
 
         foreach (var part in _score.Parts)
-        foreach (var measure in part.Measures)
-        foreach (var note in measure.Notes)
-        {
-            if (note.IsRest || note.MidiPitch < MinMidi || note.MidiPitch > MaxMidi) continue;
+            foreach (var measure in part.Measures)
+                foreach (var note in measure.Notes)
+                {
+                    if (note.IsRest || note.MidiPitch < MinMidi || note.MidiPitch > MaxMidi) continue;
 
-            int divs = Math.Max(1, measure.Divisions);
-            double xFrac   = (double)note.OnsetDivisions / (divs * 4);
-            double wFrac   = (double)note.Duration        / (divs * 4);
-            double x       = YAxisW + (measure.Number - 1) * MeasureW + xFrac * MeasureW;
-            double w       = Math.Max(1.5, wFrac * MeasureW - 1);
-            double rowTop  = _canvasH - (note.MidiPitch - MinMidi + 1) * KeyH + 1;
+                    int divs = Math.Max(1, measure.Divisions);
+                    double xFrac = (double)note.OnsetDivisions / (divs * 4);
+                    double wFrac = (double)note.Duration / (divs * 4);
+                    double x = YAxisW + (measure.Number - 1) * MeasureW + xFrac * MeasureW;
+                    double w = Math.Max(1.5, wFrac * MeasureW - 1);
+                    double rowTop = _canvasH - (note.MidiPitch - MinMidi + 1) * KeyH + 1;
 
-            int visualStaff = _score.VisualStaff(part, note);
-            double ny, nh;
-            IBrush brush;
-            if (visualStaff == 1)      { ny = rowTop;         nh = halfH;     brush = staff1Brush; }
-            else if (visualStaff == 2) { ny = rowTop + halfH; nh = halfH;     brush = staff2Brush; }
-            else                       { ny = rowTop;         nh = KeyH - 2;  brush = otherBrush; }
+                    int visualStaff = _score.VisualStaff(part, note);
+                    double ny, nh;
+                    IBrush brush;
+                    if (visualStaff == 1) { ny = rowTop; nh = halfH; brush = staff1Brush; }
+                    else if (visualStaff == 2) { ny = rowTop + halfH; nh = halfH; brush = staff2Brush; }
+                    else { ny = rowTop; nh = KeyH - 2; brush = otherBrush; }
 
-            ctx.FillRectangle(brush, new Rect(x, ny, w, nh));
-        }
+                    ctx.FillRectangle(brush, new Rect(x, ny, w, nh));
+                }
 
         RenderOverlay(ctx);
     }
@@ -1195,19 +1199,19 @@ internal class PianoRollCanvas : Control
 /// </summary>
 internal sealed class RhythmDensityCanvas : Control
 {
-    private const int Slots       = 16;   // 16th-note positions per measure
-    private const int BarW        = 40;
-    private const int LabelH      = 24;
-    private const int LegendH     = 20;
+    private const int Slots = 16;   // 16th-note positions per measure
+    private const int BarW = 40;
+    private const int LabelH = 24;
+    private const int LegendH = 20;
     private readonly MxlScore _score;
-    private readonly int[]   _staff1 = new int[Slots];
-    private readonly int[]   _staff2 = new int[Slots];
-    private readonly double  _canvasW;
-    private readonly double  _canvasH = 420;
+    private readonly int[] _staff1 = new int[Slots];
+    private readonly int[] _staff2 = new int[Slots];
+    private readonly double _canvasW;
+    private readonly double _canvasH = 420;
 
     public RhythmDensityCanvas(MxlScore score)
     {
-        _score  = score;
+        _score = score;
         _canvasW = Slots * BarW + 60;
         BuildHistogram();
     }
@@ -1215,40 +1219,40 @@ internal sealed class RhythmDensityCanvas : Control
     private void BuildHistogram()
     {
         foreach (var part in _score.Parts)
-        foreach (var measure in part.Measures)
-        {
-            int divs = Math.Max(1, measure.Divisions);
-            int divsPer16th = divs / 4;  // divisions per 16th note (quarter = divs)
-            if (divsPer16th < 1) divsPer16th = 1;
-
-            foreach (var note in measure.Notes)
+            foreach (var measure in part.Measures)
             {
-                if (note.IsRest || note.IsChord) continue;
-                int slot = (int)Math.Round((double)note.OnsetDivisions / divsPer16th) % Slots;
-                if (slot < 0) slot = 0;
-                if (note.Staff == 1) _staff1[slot]++;
-                else                  _staff2[slot]++;
+                int divs = Math.Max(1, measure.Divisions);
+                int divsPer16th = divs / 4;  // divisions per 16th note (quarter = divs)
+                if (divsPer16th < 1) divsPer16th = 1;
+
+                foreach (var note in measure.Notes)
+                {
+                    if (note.IsRest || note.IsChord) continue;
+                    int slot = (int)Math.Round((double)note.OnsetDivisions / divsPer16th) % Slots;
+                    if (slot < 0) slot = 0;
+                    if (note.Staff == 1) _staff1[slot]++;
+                    else _staff2[slot]++;
+                }
             }
-        }
     }
 
     protected override Size MeasureOverride(Size _) => new(_canvasW, _canvasH);
 
     public override void Render(DrawingContext ctx)
     {
-        var bg       = new SolidColorBrush(Color.FromRgb(28, 28, 28));
-        var gridPen  = new Pen(new SolidColorBrush(Color.FromRgb(60, 60, 60)), 0.5);
-        var axispen  = new Pen(new SolidColorBrush(Color.FromRgb(120, 120, 120)), 1);
-        var s1Brush  = new SolidColorBrush(Color.FromArgb(220, 64, 192, 87));
-        var s2Brush  = new SolidColorBrush(Color.FromArgb(220, 88, 130, 226));
-        var labelBr  = new SolidColorBrush(Color.FromRgb(180, 180, 180));
-        var tf       = new Typeface("Consolas");
+        var bg = new SolidColorBrush(Color.FromRgb(28, 28, 28));
+        var gridPen = new Pen(new SolidColorBrush(Color.FromRgb(60, 60, 60)), 0.5);
+        var axispen = new Pen(new SolidColorBrush(Color.FromRgb(120, 120, 120)), 1);
+        var s1Brush = new SolidColorBrush(Color.FromArgb(220, 64, 192, 87));
+        var s2Brush = new SolidColorBrush(Color.FromArgb(220, 88, 130, 226));
+        var labelBr = new SolidColorBrush(Color.FromRgb(180, 180, 180));
+        var tf = new Typeface("Consolas");
 
         ctx.FillRectangle(bg, new Rect(0, 0, _canvasW, _canvasH));
 
         int maxCount = Math.Max(1, _staff1.Concat(_staff2).Max());
         double chartH = _canvasH - LabelH - LegendH - 10;
-        double xOff   = 30;
+        double xOff = 30;
 
         // Axis
         ctx.DrawLine(axispen, new Point(xOff, 0), new Point(xOff, _canvasH - LabelH - LegendH));
@@ -1271,18 +1275,18 @@ internal sealed class RhythmDensityCanvas : Control
             ctx.FillRectangle(s1Brush, new Rect(x + BarW / 2.0, _canvasH - LabelH - LegendH - h1, BarW / 2.0 - 2, h1));
 
             // Beat label (1, 1e, 1+, 1a, 2, ...)
-            string[] beatNames = { "1","e","+","a","2","e","+","a","3","e","+","a","4","e","+","a" };
+            string[] beatNames = { "1", "e", "+", "a", "2", "e", "+", "a", "3", "e", "+", "a", "4", "e", "+", "a" };
             var ft = new FormattedText(beatNames[i], CultureInfo.InvariantCulture,
-                FlowDirection.LeftToRight, tf, 10, i % 4 == 0 ? labelBr : new SolidColorBrush(Color.FromRgb(100,100,100)));
+                FlowDirection.LeftToRight, tf, 10, i % 4 == 0 ? labelBr : new SolidColorBrush(Color.FromRgb(100, 100, 100)));
             ctx.DrawText(ft, new Point(x + BarW / 4.0, _canvasH - LabelH - LegendH + 4));
         }
 
         // Legend
         double ly = _canvasH - LegendH + 2;
-        ctx.FillRectangle(s1Brush, new Rect(xOff,        ly, 14, 10));
+        ctx.FillRectangle(s1Brush, new Rect(xOff, ly, 14, 10));
         ctx.DrawText(new FormattedText("Staff 1 (treble)", CultureInfo.InvariantCulture,
             FlowDirection.LeftToRight, tf, 10, labelBr), new Point(xOff + 18, ly));
-        ctx.FillRectangle(s2Brush, new Rect(xOff + 150,  ly, 14, 10));
+        ctx.FillRectangle(s2Brush, new Rect(xOff + 150, ly, 14, 10));
         ctx.DrawText(new FormattedText("Staff 2 (bass)", CultureInfo.InvariantCulture,
             FlowDirection.LeftToRight, tf, 10, labelBr), new Point(xOff + 168, ly));
     }
@@ -1294,10 +1298,10 @@ internal sealed class RhythmDensityCanvas : Control
 /// </summary>
 internal sealed class HandRangeCanvas : Control
 {
-    private static readonly int MinMidi  = 21;
-    private static readonly int MaxMidi  = 108;
+    private static readonly int MinMidi = 21;
+    private static readonly int MaxMidi = 108;
     private static readonly int MeasureW = 10;   // px per measure
-    private static readonly int YAxisW   = 36;
+    private static readonly int YAxisW = 36;
     private readonly MxlScore _score;
     private readonly int _totalMeasures;
     private readonly double _canvasW;
@@ -1305,10 +1309,10 @@ internal sealed class HandRangeCanvas : Control
 
     public HandRangeCanvas(MxlScore score)
     {
-        _score         = score;
+        _score = score;
         _totalMeasures = score.Parts.Max(p => p.Measures.Count);
-        _canvasW       = YAxisW + _totalMeasures * MeasureW;
-        _canvasH       = (MaxMidi - MinMidi + 1) * 4.0 + 20;
+        _canvasW = YAxisW + _totalMeasures * MeasureW;
+        _canvasH = (MaxMidi - MinMidi + 1) * 4.0 + 20;
     }
 
     private double PitchY(int midi) => _canvasH - 20 - (midi - MinMidi) * 4.0;
@@ -1317,13 +1321,13 @@ internal sealed class HandRangeCanvas : Control
 
     public override void Render(DrawingContext ctx)
     {
-        var bg       = new SolidColorBrush(Color.FromRgb(28, 28, 28));
-        var gridPen  = new Pen(new SolidColorBrush(Color.FromRgb(50, 50, 50)), 0.3);
-        var octavePen= new Pen(new SolidColorBrush(Color.FromRgb(80, 80, 80)), 0.5);
-        var s1Pen    = new Pen(new SolidColorBrush(Color.FromArgb(210, 64, 192, 87)),  2.5);
-        var s2Pen    = new Pen(new SolidColorBrush(Color.FromArgb(210, 88, 130, 226)), 2.5);
-        var labelBr  = new SolidColorBrush(Color.FromRgb(130, 130, 130));
-        var tf       = new Typeface("Consolas");
+        var bg = new SolidColorBrush(Color.FromRgb(28, 28, 28));
+        var gridPen = new Pen(new SolidColorBrush(Color.FromRgb(50, 50, 50)), 0.3);
+        var octavePen = new Pen(new SolidColorBrush(Color.FromRgb(80, 80, 80)), 0.5);
+        var s1Pen = new Pen(new SolidColorBrush(Color.FromArgb(210, 64, 192, 87)), 2.5);
+        var s2Pen = new Pen(new SolidColorBrush(Color.FromArgb(210, 88, 130, 226)), 2.5);
+        var labelBr = new SolidColorBrush(Color.FromRgb(130, 130, 130));
+        var tf = new Typeface("Consolas");
 
         ctx.FillRectangle(bg, new Rect(0, 0, _canvasW, _canvasH));
 
@@ -1347,27 +1351,27 @@ internal sealed class HandRangeCanvas : Control
 
         // Per-measure hand range lines
         foreach (var part in _score.Parts)
-        foreach (var measure in part.Measures)
-        {
-            double x = YAxisW + (measure.Number - 1) * MeasureW + MeasureW / 2.0;
-
-            foreach (var staffGroup in measure.Notes.Where(n => !n.IsRest && n.MidiPitch >= MinMidi && n.MidiPitch <= MaxMidi)
-                                                    .GroupBy(n => n.Staff))
+            foreach (var measure in part.Measures)
             {
-                int minP = staffGroup.Min(n => n.MidiPitch);
-                int maxP = staffGroup.Max(n => n.MidiPitch);
-                var pen  = staffGroup.Key == 1 ? s1Pen : s2Pen;
-                double xOffset = staffGroup.Key == 1 ? -1.5 : 1.5;
-                ctx.DrawLine(pen,
-                    new Point(x + xOffset, PitchY(minP)),
-                    new Point(x + xOffset, PitchY(maxP)));
+                double x = YAxisW + (measure.Number - 1) * MeasureW + MeasureW / 2.0;
+
+                foreach (var staffGroup in measure.Notes.Where(n => !n.IsRest && n.MidiPitch >= MinMidi && n.MidiPitch <= MaxMidi)
+                                                        .GroupBy(n => n.Staff))
+                {
+                    int minP = staffGroup.Min(n => n.MidiPitch);
+                    int maxP = staffGroup.Max(n => n.MidiPitch);
+                    var pen = staffGroup.Key == 1 ? s1Pen : s2Pen;
+                    double xOffset = staffGroup.Key == 1 ? -1.5 : 1.5;
+                    ctx.DrawLine(pen,
+                        new Point(x + xOffset, PitchY(minP)),
+                        new Point(x + xOffset, PitchY(maxP)));
+                }
             }
-        }
 
         // Legend
         var s1Br = new SolidColorBrush(Color.FromArgb(210, 64, 192, 87));
         var s2Br = new SolidColorBrush(Color.FromArgb(210, 88, 130, 226));
-        var wBr  = new SolidColorBrush(Color.FromRgb(180, 180, 180));
+        var wBr = new SolidColorBrush(Color.FromRgb(180, 180, 180));
         ctx.FillRectangle(s1Br, new Rect(YAxisW, _canvasH - 16, 12, 8));
         ctx.DrawText(new FormattedText("Staff 1 (treble)", CultureInfo.InvariantCulture,
             FlowDirection.LeftToRight, tf, 9, wBr), new Point(YAxisW + 16, _canvasH - 16));
@@ -1384,11 +1388,11 @@ internal sealed class HandRangeCanvas : Control
 /// </summary>
 internal sealed class HarmonyTimelineCanvas : Control
 {
-    private const int CellW   = 12;   // px per beat
-    private const int CellH   = 18;   // px per pitch class row
-    private const int YAxisW  = 26;
-    private const int XAxisH  = 16;
-    private static readonly string[] PitchNames = { "C","C#","D","Eb","E","F","F#","G","Ab","A","Bb","B" };
+    private const int CellW = 12;   // px per beat
+    private const int CellH = 18;   // px per pitch class row
+    private const int YAxisW = 26;
+    private const int XAxisH = 16;
+    private static readonly string[] PitchNames = { "C", "C#", "D", "Eb", "E", "F", "F#", "G", "Ab", "A", "Bb", "B" };
     // color wheel: each pitch class gets a distinct hue
     private static readonly Color[] PcColors =
     {
@@ -1418,7 +1422,7 @@ internal sealed class HarmonyTimelineCanvas : Control
         _score = score;
         BuildBeatMap();
         _totalBeats = _beatPcs.Count > 0 ? _beatPcs.Max(b => b.Beat) + 1 : 1;
-        _canvasW    = YAxisW + _totalBeats * CellW;
+        _canvasW = YAxisW + _totalBeats * CellW;
     }
 
     private void BuildBeatMap()
@@ -1456,10 +1460,10 @@ internal sealed class HarmonyTimelineCanvas : Control
 
     public override void Render(DrawingContext ctx)
     {
-        var bg      = new SolidColorBrush(Color.FromRgb(28, 28, 28));
+        var bg = new SolidColorBrush(Color.FromRgb(28, 28, 28));
         var labelBr = new SolidColorBrush(Color.FromRgb(160, 160, 160));
-        var emptyBr = new SolidColorBrush(Color.FromRgb(45,  45,  45));
-        var tf      = new Typeface("Consolas");
+        var emptyBr = new SolidColorBrush(Color.FromRgb(45, 45, 45));
+        var tf = new Typeface("Consolas");
 
         ctx.FillRectangle(bg, new Rect(0, 0, _canvasW, _canvasH));
 
@@ -1474,12 +1478,12 @@ internal sealed class HarmonyTimelineCanvas : Control
 
         // Empty grid
         for (int beat = 0; beat < _totalBeats; beat++)
-        for (int pc = 0; pc < 12; pc++)
-        {
-            double x = YAxisW + beat * CellW;
-            double y = pc * CellH;
-            ctx.FillRectangle(emptyBr, new Rect(x + 0.5, y + 0.5, CellW - 1, CellH - 1));
-        }
+            for (int pc = 0; pc < 12; pc++)
+            {
+                double x = YAxisW + beat * CellW;
+                double y = pc * CellH;
+                ctx.FillRectangle(emptyBr, new Rect(x + 0.5, y + 0.5, CellW - 1, CellH - 1));
+            }
 
         // Filled cells
         foreach (var (beat, pc) in _beatPcs)

--- a/AvaloniaTests/Tests/MxlVisualizationManualTests.cs
+++ b/AvaloniaTests/Tests/MxlVisualizationManualTests.cs
@@ -42,7 +42,7 @@ public class MxlVisualizationManualTests : TestBase
     // - Edit this relative path to point at the .mxl you want to inspect -
     private string AdhocMxlPath =>
         Path.Combine(GetSheetMusicFolder(), @"Pop\SangahNoonaSingles\Tico-Tico no Fubá - A Minor - MN0227296 - Tico-Tico no Fubá - A Minor - MN0227296.mxl");
-
+    // "C:\Users\Calvi\OneDrive\SheetMusic\Pop\KristenMoscaSingles\Mary Poppins Rag - G Major - MN0189186 - Mary Poppins Rag - G Major - MN0189186.mxl"
     // -
 
     // -----------------------------------------------------------------------
@@ -212,7 +212,7 @@ public class MxlVisualizationManualTests : TestBase
         if (!OperatingSystem.IsWindows())
             Assert.Inconclusive("MIDI playback requires Windows (winmm.dll).");
         var score = ParseMxl(AdhocMxlPath);
-        await ShowVerticalPianoRollWindowAsync(AdhocMxlPath, score, syncDiagnostics: false);
+        await ShowVerticalPianoRollWindowAsync(AdhocMxlPath, score, startMeasure:45, syncDiagnostics: true);
     }
 
     /// <summary>

--- a/AvaloniaTests/Tests/MxlVisualizationManualTests.cs
+++ b/AvaloniaTests/Tests/MxlVisualizationManualTests.cs
@@ -211,7 +211,7 @@ public class MxlVisualizationManualTests : TestBase
     {
         if (!OperatingSystem.IsWindows())
             Assert.Inconclusive("MIDI playback requires Windows (winmm.dll).");
-        var pathToMxl = Path.Combine(GetSheetMusicFolder(), @"Pop\SangahNoonaSingles\Happy Birthday to You! - F Major - MK0108772.mxl");
+        var pathToMxl = Path.Combine(GetSheetMusicFolder(), @"Pop\KristenMoscaSingles\Cantina Band - Cantina Band.mxl");
 
         var score = ParseMxl(pathToMxl);
         await ShowVerticalPianoRollWindowAsync(pathToMxl, score, startMeasure: 0, syncDiagnostics: true);

--- a/AvaloniaTests/Tests/VerticalPianoRollTests.cs
+++ b/AvaloniaTests/Tests/VerticalPianoRollTests.cs
@@ -261,6 +261,119 @@ public class VerticalPianoRollTests
         Assert.AreEqual(24, a4.OnsetDivisions, "A4 onset should be 24 within measure 2");
     }
 
+    // ── Tied-note merging ────────────────────────────────────────────────────
+
+    private static string TieMxl(string measuresXml) => $@"<?xml version=""1.0"" encoding=""UTF-8""?>
+<score-partwise version=""3.1"">
+  <movement-title>TieTest</movement-title>
+  <part-list><score-part id=""P1""><part-name>Piano</part-name></score-part></part-list>
+  <part id=""P1"">{measuresXml}</part>
+</score-partwise>";
+
+    [TestMethod]
+    public void MxlScore_Parse_TiedNotes_WithinMeasure_MergedIntoOne()
+    {
+        // Two quarter C4s tied within the same measure → one half-note bar, second note absorbed.
+        var xml = TieMxl(@"
+<measure number=""1"">
+  <attributes><divisions>4</divisions><time><beats>4</beats><beat-type>4</beat-type></time></attributes>
+  <note><pitch><step>C</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type>
+    <tie type=""start""/></note>
+  <note><pitch><step>C</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type>
+    <tie type=""stop""/></note>
+  <note><pitch><step>E</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+  <note><pitch><step>G</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+</measure>");
+
+        var score  = MxlScore.Parse(xml);
+        var notes  = score.Parts[0].Measures[0].Notes;
+        var c4open = notes.First(n => n.Pitch == "C" && !n.IsAbsorbed);
+        var c4cont = notes.First(n => n.Pitch == "C" && n.IsAbsorbed);
+
+        Assert.IsFalse(c4open.IsAbsorbed,  "Opener should not be absorbed");
+        Assert.IsTrue (c4cont.IsAbsorbed,  "Continuation should be absorbed");
+        Assert.AreEqual(8, c4open.Duration, "Opener duration should be extended to 8 (two quarters)");
+        Assert.AreEqual(0, c4open.OnsetDivisions, "Opener onset unchanged");
+    }
+
+    [TestMethod]
+    public void MxlScore_Parse_TiedNotes_CrossMeasure_MergedIntoOne()
+    {
+        // Tied C4 across a bar line: half note in m1 + quarter in m2 → one bar of duration 12.
+        var xml = TieMxl(@"
+<measure number=""1"">
+  <attributes><divisions>4</divisions><time><beats>4</beats><beat-type>4</beat-type></time></attributes>
+  <note><pitch><step>C</step><octave>4</octave></pitch><duration>8</duration><type>half</type>
+    <tie type=""start""/></note>
+  <note><pitch><step>D</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+  <note><pitch><step>E</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+</measure>
+<measure number=""2"">
+  <note><pitch><step>C</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type>
+    <tie type=""stop""/></note>
+  <note><pitch><step>F</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+  <note><pitch><step>G</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+  <note><pitch><step>A</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+</measure>");
+
+        var score = MxlScore.Parse(xml);
+        var m1    = score.Parts[0].Measures[0];
+        var m2    = score.Parts[0].Measures[1];
+
+        var opener = m1.Notes.First(n => n.Pitch == "C");
+        var cont   = m2.Notes.First(n => n.Pitch == "C");
+
+        Assert.IsFalse(opener.IsAbsorbed, "Opener in m1 must not be absorbed");
+        Assert.IsTrue (cont.IsAbsorbed,   "Continuation in m2 must be absorbed");
+        // Opener starts at onset 0 in m1 (globalOnset 0).
+        // Continuation starts at onset 0 in m2 (globalOnset 16), duration 4.
+        // Expected merged duration = (16 - 0 - 0 + 0 + 4) = 20.
+        Assert.AreEqual(20, opener.Duration, "Merged duration should span m1 half + m2 quarter = 20 divs");
+    }
+
+    [TestMethod]
+    public void MxlScore_Parse_TiedNotes_ChainedAcrossThreeMeasures()
+    {
+        // C4 tied across three measures: quarter + quarter + quarter → duration = 12.
+        var xml = TieMxl(@"
+<measure number=""1"">
+  <attributes><divisions>4</divisions><time><beats>4</beats><beat-type>4</beat-type></time></attributes>
+  <note><pitch><step>C</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type>
+    <tie type=""start""/></note>
+  <note><pitch><step>D</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+  <note><pitch><step>E</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+  <note><pitch><step>F</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+</measure>
+<measure number=""2"">
+  <note><pitch><step>C</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type>
+    <tie type=""stop""/><tie type=""start""/></note>
+  <note><pitch><step>G</step><octave>4</octave></pitch><duration>12</duration><type>dotted-half</type></note>
+</measure>
+<measure number=""3"">
+  <note><pitch><step>C</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type>
+    <tie type=""stop""/></note>
+  <note><pitch><step>A</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+  <note><pitch><step>B</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+  <note><pitch><step>D</step><octave>5</octave></pitch><duration>4</duration><type>quarter</type></note>
+</measure>");
+
+        var score = MxlScore.Parse(xml);
+        var m1    = score.Parts[0].Measures[0];
+        var m2    = score.Parts[0].Measures[1];
+        var m3    = score.Parts[0].Measures[2];
+
+        var opener = m1.Notes.First(n => n.Pitch == "C");
+        var mid    = m2.Notes.First(n => n.Pitch == "C");
+        var last   = m3.Notes.First(n => n.Pitch == "C");
+
+        Assert.IsFalse(opener.IsAbsorbed, "Opener must not be absorbed");
+        Assert.IsTrue (mid.IsAbsorbed,    "Middle link must be absorbed");
+        Assert.IsTrue (last.IsAbsorbed,   "Final link must be absorbed");
+        // globalOnset: m1=0, m2=16, m3=32.  Final C ends at 32+0+4=36.  Opener onset=0 in m1.
+        // merged duration = 36 - 0 - 0 = 36.
+        Assert.AreEqual(36, opener.Duration, "Chained tie: total duration = 3 quarters = 36 divs");
+    }
+
     [TestMethod]
     public void MxlScore_VisualStaff_GrandStaffUsesStaffElement()
     {

--- a/AvaloniaTests/Tests/VerticalPianoRollTests.cs
+++ b/AvaloniaTests/Tests/VerticalPianoRollTests.cs
@@ -134,6 +134,134 @@ public class VerticalPianoRollTests
     }
 
     [TestMethod]
+    public void MxlScore_Parse_GlobalOnsetDivisionsIsMonotonicallyNonDecreasing()
+    {
+        var score = MxlScore.Parse(MinimalMxl);
+        var measures = score.Parts[0].Measures;
+        for (int i = 1; i < measures.Count; i++)
+            Assert.IsTrue(measures[i].GlobalOnsetDivisions >= measures[i - 1].GlobalOnsetDivisions,
+                $"Measure {measures[i].Number} globalOnset {measures[i].GlobalOnsetDivisions} < previous {measures[i - 1].GlobalOnsetDivisions}");
+    }
+
+    /// <summary>
+    /// Regression test: when a score changes &lt;divisions&gt; mid-piece (e.g. 4 → 12),
+    /// all GlobalOnsetDivisions and note OnsetDivisions must still be expressed in the
+    /// canonical (first-measure) unit.  Before the fix, notes in the high-divisions
+    /// section appeared 3× ahead of the SyncAnchor predictor, causing visible jumps.
+    /// </summary>
+    [TestMethod]
+    public void MxlScore_Parse_DivisionsChange_NormalisesToCanonicalUnit()
+    {
+        // Two measures: first uses divisions=4, second changes to divisions=12.
+        // A quarter note at divisions=4 has duration=4; at divisions=12 has duration=12.
+        // Both should land at the same canonical tick after normalisation.
+        const string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<score-partwise version=""3.1"">
+  <movement-title>DivTest</movement-title>
+  <part-list><score-part id=""P1""><part-name>Piano</part-name></score-part></part-list>
+  <part id=""P1"">
+    <measure number=""1"">
+      <attributes>
+        <divisions>4</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>4</duration><type>quarter</type></note>
+    </measure>
+    <measure number=""2"">
+      <attributes><divisions>12</divisions></attributes>
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>12</duration><type>quarter</type></note>
+      <note><pitch><step>A</step><octave>4</octave></pitch><duration>12</duration><type>quarter</type></note>
+      <note><pitch><step>B</step><octave>4</octave></pitch><duration>12</duration><type>quarter</type></note>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>12</duration><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>";
+
+        var score   = MxlScore.Parse(xml);
+        var part    = score.Parts[0];
+        var m1      = part.Measures[0];
+        var m2      = part.Measures[1];
+
+        // Both measures store the canonical (divisions=4) unit.
+        Assert.AreEqual(4, m1.Divisions, "Measure 1 should store canonical divisions=4");
+        Assert.AreEqual(4, m2.Divisions, "Measure 2 should store canonical divisions=4 after normalisation");
+
+        // Measure 2 starts exactly one 4/4 measure after measure 1 (4 beats × 4 divs = 16 ticks).
+        Assert.AreEqual(0L,  m1.GlobalOnsetDivisions, "Measure 1 globalOnset should be 0");
+        Assert.AreEqual(16L, m2.GlobalOnsetDivisions, "Measure 2 globalOnset should be 16 (one 4/4 measure)");
+
+        // Notes in measure 2 must have OnsetDivisions and Duration scaled to canonical unit (÷3).
+        var g4 = m2.Notes.First(n => n.Pitch == "G");
+        Assert.AreEqual(0,  g4.OnsetDivisions, "G4 onset should be 0 within measure 2");
+        Assert.AreEqual(4,  g4.Duration,        "G4 duration should be 4 (canonical quarter)");
+
+        var a4 = m2.Notes.First(n => n.Pitch == "A");
+        Assert.AreEqual(4, a4.OnsetDivisions, "A4 onset should be 4 within measure 2");
+    }
+
+    /// <summary>
+    /// Regression test for downward divisions change (e.g. 24 → 2).
+    /// Before the fix, divScale = 24/2 = 12 caused notes to be ÷12 instead of ×12,
+    /// producing GlobalOnsetDivisions that advanced only 8 ticks per measure instead of 96,
+    /// making those measures play ~12× too fast visually.
+    /// </summary>
+    [TestMethod]
+    public void MxlScore_Parse_DivisionsDecrease_NormalisesToCanonicalUnit()
+    {
+        // Measure 1: divisions=24 (canonical). Measure 2: divisions=2 (smaller, e.g. after Audiveris simplification).
+        // A quarter note at div=24 has duration=24; at div=2 has duration=2.
+        // After normalisation both should be 24 (canonical quarter).
+        const string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<score-partwise version=""3.1"">
+  <movement-title>DivDecreaseTest</movement-title>
+  <part-list><score-part id=""P1""><part-name>Piano</part-name></score-part></part-list>
+  <part id=""P1"">
+    <measure number=""1"">
+      <attributes>
+        <divisions>24</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>24</duration><type>quarter</type></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>24</duration><type>quarter</type></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>24</duration><type>quarter</type></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>24</duration><type>quarter</type></note>
+    </measure>
+    <measure number=""2"">
+      <attributes><divisions>2</divisions></attributes>
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>2</duration><type>quarter</type></note>
+      <note><pitch><step>A</step><octave>4</octave></pitch><duration>2</duration><type>quarter</type></note>
+      <note><pitch><step>B</step><octave>4</octave></pitch><duration>2</duration><type>quarter</type></note>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>2</duration><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>";
+
+        var score = MxlScore.Parse(xml);
+        var part  = score.Parts[0];
+        var m1    = part.Measures[0];
+        var m2    = part.Measures[1];
+
+        // Both measures store the canonical (divisions=24) unit.
+        Assert.AreEqual(24, m1.Divisions, "Measure 1 should store canonical divisions=24");
+        Assert.AreEqual(24, m2.Divisions, "Measure 2 should store canonical divisions=24 after normalisation");
+
+        // Measure 2 starts exactly one 4/4 measure after measure 1 (4 beats × 24 divs = 96 ticks).
+        Assert.AreEqual(0L,  m1.GlobalOnsetDivisions, "Measure 1 globalOnset should be 0");
+        Assert.AreEqual(96L, m2.GlobalOnsetDivisions, "Measure 2 globalOnset should be 96 (one 4/4 measure at div=24)");
+
+        // Notes in measure 2 must have OnsetDivisions and Duration scaled up to canonical unit (×12).
+        var g4 = m2.Notes.First(n => n.Pitch == "G");
+        Assert.AreEqual(0,  g4.OnsetDivisions, "G4 onset should be 0 within measure 2");
+        Assert.AreEqual(24, g4.Duration,        "G4 duration should be 24 (canonical quarter at div=24)");
+
+        var a4 = m2.Notes.First(n => n.Pitch == "A");
+        Assert.AreEqual(24, a4.OnsetDivisions, "A4 onset should be 24 within measure 2");
+    }
+
+    [TestMethod]
     public void MxlScore_VisualStaff_GrandStaffUsesStaffElement()
     {
         // Measure 2 has notes on staff 1 and staff 2 → isMultiStaff = true

--- a/SheetMusicLib/AppSettings.cs
+++ b/SheetMusicLib/AppSettings.cs
@@ -345,6 +345,18 @@ public class AppSettings
     /// </summary>
     public string? LastSelectedPlaylist { get; set; }
 
+    /// <summary>
+    /// User-created piano-roll auto-play playlists.
+    /// This data ROAMS with the music folder.
+    /// </summary>
+    public List<PianoRollPlaylist> PianoRollPlaylists { get; set; } = new();
+
+    /// <summary>
+    /// Name of the last selected piano-roll playlist.
+    /// This data ROAMS with the music folder.
+    /// </summary>
+    public string? LastSelectedPianoRollPlaylist { get; set; }
+
     #endregion
 
     #region Local Machine Settings (window state, MRU, etc.) - LOCAL ONLY
@@ -520,6 +532,8 @@ public class AppSettings
 
                     Playlists = roamingSettings.Playlists ?? new List<Playlist>();
                     LastSelectedPlaylist = roamingSettings.LastSelectedPlaylist;
+                    PianoRollPlaylists = roamingSettings.PianoRollPlaylists ?? new List<PianoRollPlaylist>();
+                    LastSelectedPianoRollPlaylist = roamingSettings.LastSelectedPianoRollPlaylist;
                     Logger.LogInfo($"LoadRoamingFromMusicFolder: Now have {Playlists.Count} playlists, LastSelected={LastSelectedPlaylist}");
                     if (roamingSettings.UserOptions != null)
                     {
@@ -534,6 +548,8 @@ public class AppSettings
                 Logger.LogWarning($"LoadRoamingFromMusicFolder: File does not exist: {roamingPath}");
                 Playlists = new List<Playlist>();
                 LastSelectedPlaylist = null;
+                PianoRollPlaylists = new List<PianoRollPlaylist>();
+                LastSelectedPianoRollPlaylist = null;
             }
         }
         catch (Exception ex)
@@ -645,7 +661,9 @@ public class AppSettings
             {
                 UserOptions = UserOptions,
                 Playlists = Playlists,
-                LastSelectedPlaylist = LastSelectedPlaylist
+                LastSelectedPlaylist = LastSelectedPlaylist,
+                PianoRollPlaylists = PianoRollPlaylists,
+                LastSelectedPianoRollPlaylist = LastSelectedPianoRollPlaylist
             };
 
             var json = JsonSerializer.Serialize(roamingSettings, JsonOptions);
@@ -739,6 +757,8 @@ public class AppSettings
         // Reset playlists
         Playlists.Clear();
         LastSelectedPlaylist = null;
+        PianoRollPlaylists.Clear();
+        LastSelectedPianoRollPlaylist = null;
     }
 
     /// <summary>
@@ -815,5 +835,7 @@ public class AppSettings
         public UserOptionsSettings UserOptions { get; set; } = new();
         public List<Playlist> Playlists { get; set; } = new();
         public string? LastSelectedPlaylist { get; set; }
+        public List<PianoRollPlaylist> PianoRollPlaylists { get; set; } = new();
+        public string? LastSelectedPianoRollPlaylist { get; set; }
     }
 }

--- a/SheetMusicLib/MusicDataTypes.cs
+++ b/SheetMusicLib/MusicDataTypes.cs
@@ -219,4 +219,42 @@ namespace SheetMusicLib
             return $"{Name} ({Entries.Count} songs)";
         }
     }
+
+    /// <summary>
+    /// A single entry in a piano-roll auto-play playlist.
+    /// Stores the path to the cached .mxl file and a display name shown in the UI.
+    /// </summary>
+    [Serializable]
+    public class PianoRollPlaylistEntry
+    {
+        /// <summary>Full path to the cached .mxl (or plain .xml / .musicxml) file.</summary>
+        public string MxlPath { get; set; } = string.Empty;
+
+        /// <summary>Human-readable song title shown in the playlist and the piano-roll overlay.</summary>
+        public string DisplayName { get; set; } = string.Empty;
+
+        public override string ToString() => DisplayName;
+    }
+
+    /// <summary>
+    /// A named ordered list of songs for the piano-roll "player piano" mode.
+    /// Songs are played sequentially; the piano roll auto-advances on completion.
+    /// </summary>
+    [Serializable]
+    public class PianoRollPlaylist
+    {
+        /// <summary>Name of this piano-roll playlist.</summary>
+        public string Name { get; set; } = "New PianoRoll Playlist";
+
+        /// <summary>When the playlist was created.</summary>
+        public DateTime CreatedDate { get; set; } = DateTime.Now;
+
+        /// <summary>When the playlist was last modified.</summary>
+        public DateTime ModifiedDate { get; set; } = DateTime.Now;
+
+        /// <summary>Ordered song entries.</summary>
+        public List<PianoRollPlaylistEntry> Entries { get; set; } = new();
+
+        public override string ToString() => $"{Name} ({Entries.Count} songs)";
+    }
 }

--- a/SheetMusicViewer.Desktop/ChooseMusicWindow.cs
+++ b/SheetMusicViewer.Desktop/ChooseMusicWindow.cs
@@ -51,6 +51,15 @@ public class ChooseMusicWindow : Window
     private Grid _playlistTabGrid;
     private Playlist? _currentPlaylist;
 
+    // PianoRoll playlist tab
+    private ComboBox _pianoRollPlaylistComboBox;
+    private BrowseControl? _pianoRollPlaylistEntriesBrowseControl;
+    private BrowseControl? _pianoRollSongsBrowseControl;
+    private TextBlock _pianoRollPlaylistStatus;
+    private Grid _pianoRollTabGrid;
+    private PianoRollPlaylist? _currentPianoRollPlaylist;
+    private bool _isRefreshingPianoRollCombo = false;
+
     private List<PdfMetaDataReadResult> _pdfMetadata;
     private string _rootFolder;
 
@@ -203,6 +212,10 @@ public class ChooseMusicWindow : Window
                     _tabControl.SelectedIndex = 3;
                     e.Handled = true;
                     break;
+                case Key.R: // Piano_Roll
+                    _tabControl.SelectedIndex = 4;
+                    e.Handled = true;
+                    break;
             }
         }
     }
@@ -330,6 +343,11 @@ public class ChooseMusicWindow : Window
         var playlistTab = new TabItem { Header = "_Playlists" };
         playlistTab.Content = BuildPlaylistTabContent();
         _tabControl.Items.Add(playlistTab);
+
+        // PianoRoll playlist tab
+        var pianoRollTab = new TabItem { Header = "Piano_Roll" };
+        pianoRollTab.Content = BuildPianoRollTabContent();
+        _tabControl.Items.Add(pianoRollTab);
 
         _tabControl.SelectionChanged += OnTabSelectionChanged;
 
@@ -839,6 +857,142 @@ public class ChooseMusicWindow : Window
         return _playlistTabGrid;
     }
 
+    private Control BuildPianoRollTabContent()
+    {
+        _pianoRollTabGrid = new Grid();
+        _pianoRollTabGrid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));  // Toolbar
+        _pianoRollTabGrid.RowDefinitions.Add(new RowDefinition(new GridLength(1, GridUnitType.Star))); // Content
+
+        // Toolbar: playlist selector, management buttons, and Play button
+        var toolbar = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Margin = new Thickness(5),
+            Spacing = 10
+        };
+        Grid.SetRow(toolbar, 0);
+
+        toolbar.Children.Add(new Label { Content = "PianoRoll Playlist:", VerticalAlignment = VerticalAlignment.Center });
+
+        _pianoRollPlaylistComboBox = new ComboBox { Width = 200, VerticalAlignment = VerticalAlignment.Center };
+        _pianoRollPlaylistComboBox.SelectionChanged += OnPianoRollPlaylistSelectionChanged;
+        toolbar.Children.Add(_pianoRollPlaylistComboBox);
+
+        var btnNew = new Button { Content = "New", Margin = new Thickness(5, 0, 0, 0) };
+        btnNew.Click += OnNewPianoRollPlaylistClick;
+        toolbar.Children.Add(btnNew);
+
+        var btnRename = new Button { Content = "Rename", Margin = new Thickness(5, 0, 0, 0) };
+        btnRename.Click += OnRenamePianoRollPlaylistClick;
+        toolbar.Children.Add(btnRename);
+
+        var btnDelete = new Button { Content = "Delete", Margin = new Thickness(5, 0, 0, 0) };
+        btnDelete.Click += OnDeletePianoRollPlaylistClick;
+        toolbar.Children.Add(btnDelete);
+
+        var btnPlay = new Button
+        {
+            Content = "▶ Play PianoRoll",
+            Margin = new Thickness(20, 0, 0, 0),
+            [ToolTip.TipProperty] = "Open the piano roll and auto-play all songs in this playlist"
+        };
+        btnPlay.Click += OnPlayPianoRollClick;
+        toolbar.Children.Add(btnPlay);
+
+        _pianoRollPlaylistStatus = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(20, 0, 0, 0)
+        };
+        toolbar.Children.Add(_pianoRollPlaylistStatus);
+
+        _pianoRollTabGrid.Children.Add(toolbar);
+
+        // Split view: MXL songs on left, playlist entries on right
+        var splitGrid = new Grid();
+        splitGrid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star))); // MXL songs browser
+        splitGrid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));                       // Buttons
+        splitGrid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star))); // Playlist entries
+        Grid.SetRow(splitGrid, 1);
+
+        var songsBrowserPlaceholder = new TextBlock
+        {
+            Text = "Loading songs with MXL...",
+            Margin = new Thickness(20),
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalAlignment = HorizontalAlignment.Center
+        };
+        Grid.SetColumn(songsBrowserPlaceholder, 0);
+        splitGrid.Children.Add(songsBrowserPlaceholder);
+
+        // Middle: Add/Remove/Up/Down buttons
+        var buttonPanel = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(5)
+        };
+        Grid.SetColumn(buttonPanel, 1);
+
+        var btnAdd = new Button
+        {
+            Content = "Copy →",
+            Width = 80,
+            Margin = new Thickness(0, 5, 0, 5),
+            HorizontalContentAlignment = HorizontalAlignment.Center,
+            [ToolTip.TipProperty] = "Add selected song(s) to piano-roll playlist"
+        };
+        btnAdd.Click += OnAddToPianoRollPlaylistClick;
+        buttonPanel.Children.Add(btnAdd);
+
+        var btnRemove = new Button
+        {
+            Content = "← Delete",
+            Width = 80,
+            Margin = new Thickness(0, 5, 0, 5),
+            HorizontalContentAlignment = HorizontalAlignment.Center,
+            [ToolTip.TipProperty] = "Remove selected song(s) from piano-roll playlist"
+        };
+        btnRemove.Click += OnRemoveFromPianoRollPlaylistClick;
+        buttonPanel.Children.Add(btnRemove);
+
+        var btnMoveUp = new Button
+        {
+            Content = "↑ Up",
+            Width = 80,
+            Margin = new Thickness(0, 15, 0, 5),
+            HorizontalContentAlignment = HorizontalAlignment.Center
+        };
+        btnMoveUp.Click += OnPianoRollMoveUpClick;
+        buttonPanel.Children.Add(btnMoveUp);
+
+        var btnMoveDown = new Button
+        {
+            Content = "↓ Down",
+            Width = 80,
+            Margin = new Thickness(0, 5, 0, 5),
+            HorizontalContentAlignment = HorizontalAlignment.Center
+        };
+        btnMoveDown.Click += OnPianoRollMoveDownClick;
+        buttonPanel.Children.Add(btnMoveDown);
+
+        splitGrid.Children.Add(buttonPanel);
+
+        var entriesPlaceholder = new TextBlock
+        {
+            Text = "Select a piano-roll playlist...",
+            Margin = new Thickness(20),
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalAlignment = HorizontalAlignment.Center
+        };
+        Grid.SetColumn(entriesPlaceholder, 2);
+        splitGrid.Children.Add(entriesPlaceholder);
+
+        _pianoRollTabGrid.Children.Add(splitGrid);
+
+        return _pianoRollTabGrid;
+    }
+
     private void OnTabSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
         // Prevent re-entrancy - setting combo box selection can trigger this again
@@ -932,6 +1086,24 @@ public class ChooseMusicWindow : Window
 
                     // Focus the filter textbox when Playlist tab is activated
                     _playlistSongsBrowseControl?.FocusFilter();
+                }
+                else if (header == "Piano_Roll")
+                {
+                    if (_queryBrowseControl != null)
+                    {
+                        _queryFilterText = _queryBrowseControl.GetFilterText();
+                    }
+
+                    if (_pianoRollSongsBrowseControl == null)
+                    {
+                        FillPianoRollTab();
+                    }
+                    else
+                    {
+                        RefreshPianoRollPlaylistUIFromSettings();
+                    }
+
+                    _pianoRollSongsBrowseControl?.FocusFilter();
                 }
             }
         }
@@ -1348,6 +1520,179 @@ public class ChooseMusicWindow : Window
         _playlistStatus.Text = $"{_currentPlaylist.Entries.Count} song(s)";
     }
 
+    // ── PianoRoll playlist tab fill / refresh ──────────────────────────────────
+
+    private void FillPianoRollTab()
+    {
+        if (_pdfMetadata.Count == 0) return;
+
+        // Collect all TocEntry items that have a cached MXL file.
+        // We need the same CachedMxlPath resolution logic used in MetaDataFormWindow.
+        var mxlSongs = new List<(string MxlPath, string DisplayName, string BookName, string Composer)>();
+
+        foreach (var pdfItem in _pdfMetadata)
+        {
+            string? mxlPersistDir = null;
+            if (AppSettings.Instance.PersistMxlNextToPdf)
+            {
+                var pdfPath = pdfItem.GetFullPathFileFromVolno(0);
+                if (!string.IsNullOrEmpty(pdfPath))
+                    mxlPersistDir = Path.GetDirectoryName(pdfPath);
+            }
+            if (mxlPersistDir == null) continue;
+
+            var orderedToc = pdfItem.TocEntries.OrderBy(t => t.PageNo).ToList();
+            int tocOffset  = pdfItem.PageNumberOffset;
+            int totalPages = pdfItem.NumPagesInSet;
+
+            for (int i = 0; i < orderedToc.Count; i++)
+            {
+                var toc = orderedToc[i];
+                int startSheet = toc.PageNo - tocOffset + 1;
+                int endSheet   = (i + 1 < orderedToc.Count)
+                    ? orderedToc[i + 1].PageNo - tocOffset
+                    : totalPages;
+                endSheet = Math.Max(startSheet, endSheet);
+
+                string? songName = orderedToc.Count > 1 ? toc.SongName : null;
+                string? mxlPath =
+                    MuseScoreExportService.FindCachedMxlPath(pdfItem, startSheet, endSheet, false, mxlPersistDir, songName)
+                    ?? MuseScoreExportService.FindCachedMxlPath(pdfItem, startSheet, endSheet, true, mxlPersistDir, songName);
+
+                if (!string.IsNullOrEmpty(mxlPath))
+                    mxlSongs.Add((mxlPath, toc.SongName ?? string.Empty,
+                        pdfItem.GetBookName(_rootFolder), toc.Composer ?? string.Empty));
+            }
+        }
+
+        var query = from s in mxlSongs
+                    orderby s.DisplayName
+                    select new
+                    {
+                        s.DisplayName,
+                        s.Composer,
+                        s.BookName,
+                        _MxlPath = s.MxlPath
+                    };
+
+        _pianoRollSongsBrowseControl = new BrowseControl(query,
+            colWidths: new[] { 280, 160, 300, 0 },
+            rowHeight: BrowseControl.TouchRowHeight);
+
+        _pianoRollSongsBrowseControl.ListView.DoubleTapped += (s, e) => OnAddToPianoRollPlaylistClick(s, e);
+
+        // Replace placeholder with the browse control
+        var splitGrid = (Grid)_pianoRollTabGrid.Children[1];
+        var placeholder = splitGrid.Children.FirstOrDefault(c => Grid.GetColumn(c) == 0);
+        if (placeholder != null) splitGrid.Children.Remove(placeholder);
+        Grid.SetColumn(_pianoRollSongsBrowseControl, 0);
+        splitGrid.Children.Add(_pianoRollSongsBrowseControl);
+
+        // Populate playlist combo
+        _isRefreshingPianoRollCombo = true;
+        try
+        {
+            _pianoRollPlaylistComboBox.Items.Clear();
+            foreach (var pl in AppSettings.Instance.PianoRollPlaylists)
+                _pianoRollPlaylistComboBox.Items.Add(new ComboBoxItem { Content = pl.Name, Tag = pl });
+
+            var lastName = AppSettings.Instance.LastSelectedPianoRollPlaylist;
+            if (!string.IsNullOrEmpty(lastName) && AppSettings.Instance.PianoRollPlaylists.Any(p => p.Name == lastName))
+            {
+                _currentPianoRollPlaylist = AppSettings.Instance.PianoRollPlaylists.First(p => p.Name == lastName);
+                _pianoRollPlaylistComboBox.SelectedItem = _pianoRollPlaylistComboBox.Items
+                    .OfType<ComboBoxItem>().FirstOrDefault(i => i.Content?.ToString() == lastName);
+            }
+            else if (AppSettings.Instance.PianoRollPlaylists.Count > 0)
+            {
+                _currentPianoRollPlaylist = AppSettings.Instance.PianoRollPlaylists[0];
+                _pianoRollPlaylistComboBox.SelectedIndex = 0;
+            }
+            else
+            {
+                _currentPianoRollPlaylist = null;
+            }
+        }
+        finally
+        {
+            _isRefreshingPianoRollCombo = false;
+        }
+
+        RefreshPianoRollEntries();
+    }
+
+    private void RefreshPianoRollPlaylistUIFromSettings()
+    {
+        var previousName = _currentPianoRollPlaylist?.Name;
+
+        _isRefreshingPianoRollCombo = true;
+        try
+        {
+            _pianoRollPlaylistComboBox.Items.Clear();
+            foreach (var pl in AppSettings.Instance.PianoRollPlaylists)
+                _pianoRollPlaylistComboBox.Items.Add(new ComboBoxItem { Content = pl.Name, Tag = pl });
+
+            // Try to keep the same playlist selected
+            if (!string.IsNullOrEmpty(previousName))
+            {
+                _currentPianoRollPlaylist = AppSettings.Instance.PianoRollPlaylists.FirstOrDefault(p => p.Name == previousName);
+                _pianoRollPlaylistComboBox.SelectedItem = _pianoRollPlaylistComboBox.Items
+                    .OfType<ComboBoxItem>().FirstOrDefault(i => i.Content?.ToString() == previousName);
+            }
+            if (_currentPianoRollPlaylist == null && AppSettings.Instance.PianoRollPlaylists.Count > 0)
+            {
+                _currentPianoRollPlaylist = AppSettings.Instance.PianoRollPlaylists[0];
+                _pianoRollPlaylistComboBox.SelectedIndex = 0;
+            }
+        }
+        finally
+        {
+            _isRefreshingPianoRollCombo = false;
+        }
+
+        RefreshPianoRollEntries();
+    }
+
+    private void RefreshPianoRollEntries()
+    {
+        var splitGrid = (Grid)_pianoRollTabGrid.Children[1];
+
+        if (_currentPianoRollPlaylist == null)
+        {
+            _pianoRollPlaylistStatus.Text = "No playlist selected";
+            var existing = splitGrid.Children.FirstOrDefault(c => Grid.GetColumn(c) == 2);
+            if (existing is BrowseControl) splitGrid.Children.Remove(existing);
+            var placeholder = new TextBlock
+            {
+                Text = "Select a piano-roll playlist...",
+                Margin = new Thickness(20),
+                VerticalAlignment = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Center
+            };
+            Grid.SetColumn(placeholder, 2);
+            splitGrid.Children.Add(placeholder);
+            return;
+        }
+
+        var query = _currentPianoRollPlaylist.Entries.Select((e, idx) => new
+        {
+            Order = idx + 1,
+            e.DisplayName,
+            e.MxlPath
+        });
+
+        _pianoRollPlaylistEntriesBrowseControl = new BrowseControl(query,
+            colWidths: new[] { 40, 280, 0 },
+            rowHeight: BrowseControl.TouchRowHeight);
+
+        var existing2 = splitGrid.Children.FirstOrDefault(c => Grid.GetColumn(c) == 2);
+        if (existing2 != null) splitGrid.Children.Remove(existing2);
+        Grid.SetColumn(_pianoRollPlaylistEntriesBrowseControl, 2);
+        splitGrid.Children.Add(_pianoRollPlaylistEntriesBrowseControl);
+
+        _pianoRollPlaylistStatus.Text = $"{_currentPianoRollPlaylist.Entries.Count} song(s)";
+    }
+
     private void OnPlaylistSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
         // Ignore selection changes during refresh
@@ -1596,6 +1941,191 @@ public class ChooseMusicWindow : Window
 
         // Re-select the moved item at its new position
         _playlistEntriesBrowseControl.ListView.SetSelectedIndex(selectedIndex + 1);
+    }
+
+    // ── PianoRoll playlist management handlers ─────────────────────────────────
+
+    private void OnPianoRollPlaylistSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_isRefreshingPianoRollCombo) return;
+        if (e.AddedItems.Count == 0) return;
+
+        if (e.AddedItems[0] is ComboBoxItem item && item.Tag is PianoRollPlaylist selected)
+        {
+            _currentPianoRollPlaylist = selected;
+            AppSettings.Instance.LastSelectedPianoRollPlaylist = selected.Name;
+            AppSettings.Instance.Save();
+            RefreshPianoRollEntries();
+        }
+    }
+
+    private async void OnNewPianoRollPlaylistClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        var name = await ShowInputDialogAsync("New PianoRoll Playlist", "Enter playlist name:", "New PianoRoll Playlist");
+        if (string.IsNullOrWhiteSpace(name)) return;
+
+        var baseName = name;
+        var counter = 1;
+        while (AppSettings.Instance.PianoRollPlaylists.Any(p => p.Name == name))
+            name = $"{baseName} ({counter++})";
+
+        var newPlaylist = new PianoRollPlaylist { Name = name };
+        AppSettings.Instance.PianoRollPlaylists.Add(newPlaylist);
+        AppSettings.Instance.LastSelectedPianoRollPlaylist = name;
+        AppSettings.Instance.Save();
+
+        _currentPianoRollPlaylist = newPlaylist;
+        RefreshPianoRollPlaylistUIFromSettings();
+    }
+
+    private async void OnRenamePianoRollPlaylistClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (_currentPianoRollPlaylist == null) return;
+
+        var newName = await ShowInputDialogAsync("Rename Playlist", "Enter new name:", _currentPianoRollPlaylist.Name);
+        if (string.IsNullOrWhiteSpace(newName) || newName == _currentPianoRollPlaylist.Name) return;
+
+        var baseName = newName;
+        var counter = 1;
+        while (AppSettings.Instance.PianoRollPlaylists.Any(p => p.Name == newName && p != _currentPianoRollPlaylist))
+            newName = $"{baseName} ({counter++})";
+
+        _currentPianoRollPlaylist.Name = newName;
+        _currentPianoRollPlaylist.ModifiedDate = DateTime.Now;
+        AppSettings.Instance.LastSelectedPianoRollPlaylist = newName;
+        AppSettings.Instance.Save();
+        RefreshPianoRollPlaylistUIFromSettings();
+    }
+
+    private async void OnDeletePianoRollPlaylistClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (_currentPianoRollPlaylist == null) return;
+
+        var confirm = await ShowConfirmDialogAsync("Delete Playlist", $"Delete '{_currentPianoRollPlaylist.Name}'?");
+        if (!confirm) return;
+
+        AppSettings.Instance.PianoRollPlaylists.Remove(_currentPianoRollPlaylist);
+        AppSettings.Instance.Save();
+
+        _currentPianoRollPlaylist = AppSettings.Instance.PianoRollPlaylists.FirstOrDefault();
+        RefreshPianoRollPlaylistUIFromSettings();
+    }
+
+    private void OnAddToPianoRollPlaylistClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (_currentPianoRollPlaylist == null || _pianoRollSongsBrowseControl == null) return;
+
+        var selectedItems = _pianoRollSongsBrowseControl.ListView.SelectedItems?.Cast<object>().ToList();
+        if (selectedItems == null || selectedItems.Count == 0) return;
+
+        foreach (var item in selectedItems)
+        {
+            var nameProp   = item.GetType().GetProperty("DisplayName");
+            var pathProp   = item.GetType().GetProperty("_MxlPath");
+            if (nameProp == null || pathProp == null) continue;
+
+            var displayName = nameProp.GetValue(item)?.ToString() ?? string.Empty;
+            var mxlPath     = pathProp.GetValue(item)?.ToString() ?? string.Empty;
+            if (string.IsNullOrEmpty(mxlPath)) continue;
+
+            _currentPianoRollPlaylist.Entries.Add(new PianoRollPlaylistEntry
+            {
+                DisplayName = displayName,
+                MxlPath     = mxlPath
+            });
+        }
+
+        _currentPianoRollPlaylist.ModifiedDate = DateTime.Now;
+        AppSettings.Instance.Save();
+        RefreshPianoRollEntries();
+    }
+
+    private void OnRemoveFromPianoRollPlaylistClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (_currentPianoRollPlaylist == null || _pianoRollPlaylistEntriesBrowseControl == null) return;
+
+        var selectedItems = _pianoRollPlaylistEntriesBrowseControl.ListView.SelectedItems?.Cast<object>().ToList();
+        if (selectedItems == null || selectedItems.Count == 0) return;
+
+        // Collect 0-based indices from the Order column (Order = idx+1)
+        var indicesToRemove = new List<int>();
+        foreach (var item in selectedItems)
+        {
+            var orderProp = item.GetType().GetProperty("Order");
+            if (orderProp?.GetValue(item) is int order)
+                indicesToRemove.Add(order - 1);
+        }
+
+        // Remove in descending order to preserve earlier indices
+        foreach (var idx in indicesToRemove.OrderByDescending(i => i))
+        {
+            if (idx >= 0 && idx < _currentPianoRollPlaylist.Entries.Count)
+                _currentPianoRollPlaylist.Entries.RemoveAt(idx);
+        }
+
+        _currentPianoRollPlaylist.ModifiedDate = DateTime.Now;
+        AppSettings.Instance.Save();
+        RefreshPianoRollEntries();
+    }
+
+    private void OnPianoRollMoveUpClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (_currentPianoRollPlaylist == null || _pianoRollPlaylistEntriesBrowseControl == null) return;
+
+        var selectedItem = _pianoRollPlaylistEntriesBrowseControl.ListView.SelectedItem;
+        if (selectedItem == null) return;
+
+        var orderProp = selectedItem.GetType().GetProperty("Order");
+        if (orderProp?.GetValue(selectedItem) is not int order || order <= 1) return;
+
+        int idx = order - 1;
+        var entry = _currentPianoRollPlaylist.Entries[idx];
+        _currentPianoRollPlaylist.Entries.RemoveAt(idx);
+        _currentPianoRollPlaylist.Entries.Insert(idx - 1, entry);
+
+        _currentPianoRollPlaylist.ModifiedDate = DateTime.Now;
+        AppSettings.Instance.Save();
+        RefreshPianoRollEntries();
+        _pianoRollPlaylistEntriesBrowseControl.ListView.SetSelectedIndex(idx - 1);
+    }
+
+    private void OnPianoRollMoveDownClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (_currentPianoRollPlaylist == null || _pianoRollPlaylistEntriesBrowseControl == null) return;
+
+        var selectedItem = _pianoRollPlaylistEntriesBrowseControl.ListView.SelectedItem;
+        if (selectedItem == null) return;
+
+        var orderProp = selectedItem.GetType().GetProperty("Order");
+        if (orderProp?.GetValue(selectedItem) is not int order) return;
+
+        int idx = order - 1;
+        if (idx >= _currentPianoRollPlaylist.Entries.Count - 1) return;
+
+        var entry = _currentPianoRollPlaylist.Entries[idx];
+        _currentPianoRollPlaylist.Entries.RemoveAt(idx);
+        _currentPianoRollPlaylist.Entries.Insert(idx + 1, entry);
+
+        _currentPianoRollPlaylist.ModifiedDate = DateTime.Now;
+        AppSettings.Instance.Save();
+        RefreshPianoRollEntries();
+        _pianoRollPlaylistEntriesBrowseControl.ListView.SetSelectedIndex(idx + 1);
+    }
+
+    private void OnPlayPianoRollClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (_currentPianoRollPlaylist == null || _currentPianoRollPlaylist.Entries.Count == 0)
+        {
+            _pianoRollPlaylistStatus.Text = "No songs in playlist.";
+            return;
+        }
+
+        var songs = _currentPianoRollPlaylist.Entries
+            .Select(entry => (entry.MxlPath, entry.DisplayName))
+            .ToList();
+
+        var window = VerticalPianoRollWindowFactory.BuildPlaylistWindow(songs);
+        window.Show(this);
     }
 
     /// <summary>

--- a/SheetMusicViewer.Desktop/ChooseMusicWindow.cs
+++ b/SheetMusicViewer.Desktop/ChooseMusicWindow.cs
@@ -1569,6 +1569,65 @@ public class ChooseMusicWindow : Window
                     orderby s.DisplayName
                     select new
                     {
+                        Mxl = new BrowseControl.BrowseField<string>(
+                            s.MxlPath, (field) =>
+                            {
+                                var btn = new Button
+                                {
+                                    Content = "🎵",
+                                    Padding = new Avalonia.Thickness(2),
+                                    Background = Avalonia.Media.Brushes.Transparent,
+                                    BorderThickness = new Avalonia.Thickness(0),
+                                    HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+                                    VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+                                    [ToolTip.TipProperty] = "Open in MuseScore"
+                                };
+                                btn.Click += (_, _) =>
+                                {
+                                    try
+                                    {
+                                        var museScorePath = AppSettings.Instance.MuseScorePath;
+                                        if (string.IsNullOrEmpty(museScorePath))
+                                            museScorePath = MuseScoreExportService.AutoDetectMuseScore();
+                                        if (!string.IsNullOrEmpty(museScorePath))
+                                            MuseScoreExportService.LaunchMuseScore(museScorePath, field.Data);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        System.Diagnostics.Debug.WriteLine($"Failed to launch MuseScore: {ex.Message}");
+                                    }
+                                };
+                                return btn;
+                            })
+                        { SortKey = "🎵" },
+                        Roll = new BrowseControl.BrowseField<string>(
+                            s.MxlPath, (field) =>
+                            {
+                                var btn = new Button
+                                {
+                                    Content = "🎹",
+                                    Padding = new Avalonia.Thickness(2),
+                                    Background = Avalonia.Media.Brushes.Transparent,
+                                    BorderThickness = new Avalonia.Thickness(0),
+                                    HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+                                    VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+                                    [ToolTip.TipProperty] = "Open in vertical piano roll (autoplay)"
+                                };
+                                btn.Click += (_, _) =>
+                                {
+                                    try
+                                    {
+                                        string xmlPath = VerticalPianoRollWindowFactory.ResolveMxlToXml(field.Data);
+                                        var window = VerticalPianoRollWindowFactory.BuildWindow(xmlPath);
+                                        window.Show(this);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        System.Diagnostics.Debug.WriteLine($"Failed to open piano roll: {ex.Message}");
+                                    }
+                                };
+                                return btn;
+                            }) { SortKey = "🎹" },
                         s.DisplayName,
                         s.Composer,
                         s.BookName,
@@ -1576,7 +1635,7 @@ public class ChooseMusicWindow : Window
                     };
 
         _pianoRollSongsBrowseControl = new BrowseControl(query,
-            colWidths: new[] { 280, 160, 300, 0 },
+            colWidths: new[] { 45, 45, 280, 160, 300, 0 },
             rowHeight: BrowseControl.TouchRowHeight);
 
         _pianoRollSongsBrowseControl.ListView.DoubleTapped += (s, e) => OnAddToPianoRollPlaylistClick(s, e);

--- a/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
+++ b/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
@@ -255,6 +255,8 @@ public sealed class MxlScore
                         Staff          = int.TryParse(child.Element(ns + "staff")?.Value, out var st) ? st : 1,
                         Voice          = int.TryParse(child.Element(ns + "voice")?.Value, out var v)  ? v  : 1,
                         Velocity       = noteVelocity,
+                        TieStart       = child.Elements(ns + "tie").Any(t => t.Attribute("type")?.Value == "start"),
+                        TieStop        = child.Elements(ns + "tie").Any(t => t.Attribute("type")?.Value == "stop"),
                     };
                     measure.Notes.Add(note);
 
@@ -300,6 +302,52 @@ public sealed class MxlScore
                 globalOnsetMs += Math.Min(actualMs, noteBasedMs > 0 ? noteBasedMs : actualMs);
                 part.Measures.Add(measure);
             }
+
+            // ── Tie-merge pass ────────────────────────────────────────────────────────
+            // Walk every note in chronological order.  When a TieStop note is found,
+            // locate the most recent unabsorbed TieStart note with the same MIDI pitch
+            // and extend its Duration to cover both notes.  The TieStop note is then
+            // marked IsAbsorbed so BuildBars and PlaySync skip it.
+            //
+            // Key: (midiPitch, voice) — voice disambiguates same-pitch ties on different
+            // voices (e.g. left-hand C held while right hand plays the same C).
+            var openTies = new Dictionary<(int midi, int voice), MxlNote>();
+            foreach (var measure in part.Measures)
+            {
+                foreach (var note in measure.Notes)
+                {
+                    if (note.IsRest) continue;
+                    int midi = note.MidiPitch;
+                    if (midi == 0) continue;
+                    var key = (midi, note.Voice);
+
+                    if (note.TieStop && openTies.TryGetValue(key, out var opener))
+                    {
+                        // Extend opener's duration by this note's duration.
+                        // The opener lives in a (possibly earlier) measure, so we need the
+                        // extra divisions relative to its own measure start.
+                        long openerGlobal = opener.IsAbsorbed ? 0   // defensive; should not occur
+                            : part.Measures.First(m => m.Notes.Contains(opener)).GlobalOnsetDivisions;
+                        long thisGlobal   = measure.GlobalOnsetDivisions;
+                        // Total span = distance from opener onset to this note's end.
+                        int newDuration = (int)(thisGlobal - openerGlobal
+                            - opener.OnsetDivisions + note.OnsetDivisions + note.Duration);
+                        opener.Duration = newDuration;
+                        note.IsAbsorbed = true;
+
+                        // If this tie-stop also starts a new tie, keep the opener in the map.
+                        if (!note.TieStart)
+                            openTies.Remove(key);
+                        // else: opener stays so the next TieStop extends it further.
+                    }
+
+                    // Register this note as the opener for a tie chain.
+                    if (note.TieStart && !note.IsAbsorbed)
+                        openTies[key] = note;
+                }
+            }
+            // ─────────────────────────────────────────────────────────────────────────
+
             score.Parts.Add(part);
         }
         return score;
@@ -360,6 +408,15 @@ public sealed class MxlNote
     public int    Voice           { get; set; }
     /// <summary>MIDI velocity 0–127 (parsed from MusicXML dynamics; default 64 = mf).</summary>
     public int    Velocity        { get; set; } = 64;
+    /// <summary>True when this note begins a tie (<tie type="start"/>).</summary>
+    public bool   TieStart        { get; set; }
+    /// <summary>True when this note continues a tie (<tie type="stop"/>).</summary>
+    public bool   TieStop         { get; set; }
+    /// <summary>
+    /// Set during the post-parse tie-merge pass when this note's duration has been
+    /// folded into its predecessor.  Absorbed notes are skipped by BuildBars and PlaySync.
+    /// </summary>
+    public bool   IsAbsorbed      { get; set; }
 
     /// <summary>MIDI pitch (21=A0 … 108=C8). Returns 0 for rests.</summary>
     public int MidiPitch
@@ -762,7 +819,7 @@ public sealed class MxlMidiPlayer : IDisposable
                 // Without this cap, multi-voice <backup> can push OnsetDivisions beyond the
                 // measure boundary, producing a globalDivs value that is one or more measures
                 // ahead of what the SyncAnchor predictor expects, causing visible jumps.
-                int    measureDurCap  = divs * measure.TimeSigBeats;
+                int    measureDurCap  = (int)(divs * measure.TimeSigBeats * (4.0 / Math.Max(1, measure.TimeSigBeatType)));
                 int    maxOnsetDivs   = measure.Notes
                     .Where(n => !n.IsChord)
                     .Select(n => n.OnsetDivisions + n.Duration)
@@ -782,7 +839,7 @@ public sealed class MxlMidiPlayer : IDisposable
 
                 foreach (var note in measure.Notes)
                 {
-                    if (note.IsRest || note.MidiPitch < 21 || note.MidiPitch > 108) continue;
+                    if (note.IsRest || note.IsAbsorbed || note.MidiPitch < 21 || note.MidiPitch > 108) continue;
                     int midi = note.MidiPitch;
                     int clampedOnset = Math.Min(note.OnsetDivisions, Math.Min(maxOnsetDivs, measureDurCap) - 1);
                     long globalDivs  = measure.GlobalOnsetDivisions + clampedOnset;
@@ -812,7 +869,7 @@ public sealed class MxlMidiPlayer : IDisposable
                 foreach (var m in _score.Parts[0].Measures)
                 {
                     int d = Math.Max(1, m.Divisions);
-                    int cap = d * m.TimeSigBeats;
+                    int cap = (int)(d * m.TimeSigBeats * (4.0 / Math.Max(1, m.TimeSigBeatType)));
                     // Compute the actual advance used for this measure (same logic as parser).
                     int raw = m.Notes.Where(n => !n.IsChord)
                         .Select(n => n.OnsetDivisions + n.Duration).DefaultIfEmpty(0).Max();
@@ -1102,7 +1159,7 @@ public sealed class VerticalPianoRollCanvas : Control
         foreach (var measure in part.Measures)
         foreach (var note in measure.Notes)
         {
-            if (note.IsRest || note.MidiPitch < MinMidi || note.MidiPitch > MaxMidi) continue;
+            if (note.IsRest || note.IsAbsorbed || note.MidiPitch < MinMidi || note.MidiPitch > MaxMidi) continue;
             long onset      = measure.GlobalOnsetDivisions + note.OnsetDivisions;
             long off        = onset + Math.Max(1, note.Duration);
             double x        = MidiToX(note.MidiPitch);

--- a/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
+++ b/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
@@ -2649,27 +2649,44 @@ public static class VerticalPianoRollWindowFactory
         int currentPos = 0;   // position within playOrder
 
         // ── Repeat / Shuffle controls ─────────────────────────────────────────
-        var repeatChk = new CheckBox
+        bool repeatOn  = false;
+        bool shuffleOn = false;
+
+        var repeatBtn = new Button
         {
             Content = "🔁 Repeat",
-            IsChecked = false,
+            Margin  = new Thickness(4),
+            Padding = new Thickness(8, 2),
             VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            Margin = new Thickness(4, 0),
             [ToolTip.TipProperty] = "Restart playlist from the beginning when the last song ends"
         };
-        var shuffleChk = new CheckBox
+        var shuffleBtn = new Button
         {
             Content = "🔀 Shuffle",
-            IsChecked = false,
+            Margin  = new Thickness(4),
+            Padding = new Thickness(8, 2),
             VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            Margin = new Thickness(4, 0),
             [ToolTip.TipProperty] = "Play songs in random order"
         };
 
-        // Re-shuffle everything after the current position when shuffle is toggled on.
-        shuffleChk.IsCheckedChanged += (_, _) =>
+        void UpdateToggleButton(Button btn, bool on)
         {
-            if (shuffleChk.IsChecked == true)
+            btn.Background = on ? Brushes.SteelBlue : null;
+            btn.Foreground = on ? Brushes.White     : null;
+        }
+
+        repeatBtn.Click += (_, _) =>
+        {
+            repeatOn = !repeatOn;
+            UpdateToggleButton(repeatBtn, repeatOn);
+        };
+
+        // Re-shuffle everything after the current position when shuffle is toggled on.
+        shuffleBtn.Click += (_, _) =>
+        {
+            shuffleOn = !shuffleOn;
+            UpdateToggleButton(shuffleBtn, shuffleOn);
+            if (shuffleOn)
             {
                 var rng = new Random();
                 for (int i = playOrder.Count - 1; i > currentPos; i--)
@@ -2693,8 +2710,8 @@ public static class VerticalPianoRollWindowFactory
         {
             Orientation = Avalonia.Layout.Orientation.Horizontal,
         };
-        leadingPanel.Children.Add(repeatChk);
-        leadingPanel.Children.Add(shuffleChk);
+        leadingPanel.Children.Add(repeatBtn);
+        leadingPanel.Children.Add(shuffleBtn);
 
         var player = new PianoRollPlayerControl(new PianoRollOptions
         {
@@ -2714,7 +2731,7 @@ public static class VerticalPianoRollWindowFactory
             string next;
             if (nextPos < playOrder.Count)
                 next = $"Next: {songs[playOrder[nextPos]].title}";
-            else if (repeatChk.IsChecked == true)
+            else if (repeatOn)
                 next = $"Next: {songs[playOrder[0]].title}  (repeating)";
             else
                 next = "Last song";
@@ -2748,9 +2765,9 @@ public static class VerticalPianoRollWindowFactory
             int next = currentPos + 1;
             if (next < songs.Count)
                 LoadSong(next);
-            else if (repeatChk.IsChecked == true)
+            else if (repeatOn)
             {
-                if (shuffleChk.IsChecked == true)
+                if (shuffleOn)
                 {
                     var rng = new Random();
                     for (int i = playOrder.Count - 1; i > 0; i--)
@@ -2775,13 +2792,13 @@ public static class VerticalPianoRollWindowFactory
                     await Task.Delay(2000).ConfigureAwait(false);
                     Dispatcher.UIThread.Post(() => LoadSong(next), DispatcherPriority.Normal);
                 });
-            else if (repeatChk.IsChecked == true)
+            else if (repeatOn)
                 Task.Run(async () =>
                 {
                     await Task.Delay(2000).ConfigureAwait(false);
                     Dispatcher.UIThread.Post(() =>
                     {
-                        if (shuffleChk.IsChecked == true)
+                        if (shuffleOn)
                         {
                             var rng = new Random();
                             for (int i = playOrder.Count - 1; i > 0; i--)

--- a/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
+++ b/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
@@ -25,6 +25,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Avalonia.VisualTree;
 
 namespace SheetMusicViewer.Desktop;
 
@@ -1489,6 +1490,11 @@ public sealed class StaffNotationCanvas : Control
         };
     }
 
+    /// <summary>Large title painted at the top of the staff canvas (e.g. current song in playlist mode).</summary>
+    public string HeaderLine1 { get; set; } = string.Empty;
+    /// <summary>Smaller subtitle painted below <see cref="HeaderLine1"/> (e.g. "Next: …").</summary>
+    public string HeaderLine2 { get; set; } = string.Empty;
+
     public void RefreshNotes() => InvalidateVisual();
 
     protected override Size MeasureOverride(Size available) =>
@@ -1520,6 +1526,26 @@ public sealed class StaffNotationCanvas : Control
 
         // ── background ────────────────────────────────────────────────────
         ctx.FillRectangle(new SolidColorBrush(Color.FromRgb(250, 248, 240)), new Rect(0, 0, W, H));
+
+        // ── header overlay (playlist / pattern title) ─────────────────────
+        double headerY = 6.0;
+        if (!string.IsNullOrEmpty(HeaderLine1))
+        {
+            var ft1 = new FormattedText(HeaderLine1, CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight,
+                new Typeface("Arial", FontStyle.Normal, FontWeight.SemiBold), 16,
+                new SolidColorBrush(Color.FromRgb(40, 40, 120)));
+            ctx.DrawText(ft1, new Point(ClefAreaW + 8, headerY));
+            headerY += ft1.Height + 2;
+        }
+        if (!string.IsNullOrEmpty(HeaderLine2))
+        {
+            var ft2 = new FormattedText(HeaderLine2, CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight,
+                new Typeface("Arial", FontStyle.Normal, FontWeight.Normal), 12,
+                new SolidColorBrush(Color.FromRgb(100, 100, 180)));
+            ctx.DrawText(ft2, new Point(ClefAreaW + 8, headerY));
+        }
 
         // ── staff layout ──────────────────────────────────────────────────
         // Each staff section occupies half the height.
@@ -1783,9 +1809,545 @@ public sealed class StaffNotationCanvas : Control
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-//  VerticalPianoRollWindow  — static factory
+//  PianoRollPlayerControl
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// <summary>
+/// Configuration options for <see cref="PianoRollPlayerControl"/>.
+/// All properties have sensible defaults; only set what you need to change.
+/// </summary>
+public sealed class PianoRollOptions
+{
+    /// <summary>Initial measure to start playback from (1-based). Default 1.</summary>
+    public int    StartMeasure      { get; init; } = 1;
+    /// <summary>Auto-close the host window when playback ends naturally.</summary>
+    public bool   AutoCloseOnEnd    { get; init; } = false;
+    /// <summary>Show the measure-seek slider (appropriate for single-song mode).</summary>
+    public bool   ShowMeasureSlider { get; init; } = true;
+    /// <summary>Show the Log Notes checkbox.</summary>
+    public bool   ShowLogNotes      { get; init; } = false;
+    /// <summary>Show a ⏭ Skip button after the play/pause button.</summary>
+    public bool   ShowSkipButton    { get; init; } = false;
+    /// <summary>Optional control placed at the left of the toolbar (e.g. pattern ComboBox).</summary>
+    public Control? LeadingControl  { get; init; } = null;
+    /// <summary>Initial FluidSynth checkbox state. Null = read from AppSettings.</summary>
+    public bool?  LogNotesDefault   { get; init; } = false;
+}
+
+/// <summary>
+/// A self-contained Avalonia <see cref="UserControl"/> that embeds a
+/// <see cref="VerticalPianoRollCanvas"/>, a <see cref="StaffNotationCanvas"/>,
+/// and a full playback toolbar (BPM, measure, LH/RH mutes, FluidSynth/WinMM picker).
+/// <para>
+/// Call <see cref="LoadScore"/> to load (and optionally auto-play) a score.
+/// The host window only needs to call <see cref="StopAll"/> when it closes.
+/// </para>
+/// </summary>
+public sealed class PianoRollPlayerControl : UserControl
+{
+    // ── public surface ────────────────────────────────────────────────────────
+    /// <summary>Raised on the UI thread when playback ends naturally (not when stopped/paused).</summary>
+    public event EventHandler? PlaybackEnded;
+    /// <summary>Raised on the UI thread when the current measure number changes during playback.</summary>
+    public event EventHandler<int>? MeasureChanged;
+
+    /// <summary>The staff canvas — caller may set HeaderLine1/HeaderLine2 for overlay text.</summary>
+    public StaffNotationCanvas StaffCanvas { get; }
+
+    // ── private state ─────────────────────────────────────────────────────────
+    private readonly PianoRollOptions    _opts;
+    private readonly bool                _isWindows;
+    private readonly IReadOnlyList<(int Id, string Name)> _winmmDevices;
+
+    // toolbar refs needed outside ctor
+    private readonly Button   _playPauseBtn;
+    private readonly Slider   _bpmSlider;
+    private readonly TextBlock _bpmLabel;
+    private readonly Slider?  _measureSlider;
+    private readonly TextBlock? _measureLabel;
+    private readonly TextBlock  _statusBlock;
+    private readonly CheckBox   _fluidChk;
+    private readonly CheckBox   _midiDeviceLabel_asChk; // kept as Control in toolbar
+    private readonly ComboBox   _midiDeviceCombo;
+    private readonly CheckBox   _rhChk;
+    private readonly CheckBox   _lhChk;
+    private readonly CheckBox?  _logNotesChk;
+    private readonly Button?    _skipBtn;
+    private readonly Grid       _contentGrid;
+
+    // playback state
+    private VerticalPianoRollCanvas? _canvas;
+    private MxlScore?                _currentScore;
+    private MxlMidiPlayer?           _player;
+    private bool                     _suppressMeasureSync;
+    private List<(long Divs, int Number)> _measureDivMap = new();
+    private int                      _totalMeasures = 1;
+    private Window?                  _hostWindow;
+
+    // debounce tokens
+    private CancellationTokenSource? _bpmDebCts;
+    private CancellationTokenSource? _measureDebCts;
+
+    public PianoRollPlayerControl(PianoRollOptions? options = null)
+    {
+        _opts      = options ?? new PianoRollOptions();
+        _isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        _winmmDevices = _isWindows ? WinmmMidiBackend.EnumerateDevices()
+                                   : Array.Empty<(int, string)>();
+
+        // ── content grid (piano roll left | staff right) ──────────────────
+        _contentGrid = new Grid();
+        _contentGrid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        _contentGrid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+
+        StaffCanvas = new StaffNotationCanvas(new MxlScore());   // placeholder; replaced by LoadScore
+
+        // ── toolbar controls ──────────────────────────────────────────────
+        _playPauseBtn = new Button
+        {
+            Content = "▶  Play",
+            Margin  = new Thickness(4),
+            Padding = new Thickness(8, 2)
+        };
+        _playPauseBtn.Click += OnPlayPauseClick;
+
+        _skipBtn = _opts.ShowSkipButton ? new Button
+        {
+            Content = "⏭  Skip",
+            Margin  = new Thickness(4),
+            Padding = new Thickness(8, 2),
+            [ToolTip.TipProperty] = "Skip to next song"
+        } : null;
+
+        _bpmSlider = new Slider
+        {
+            Minimum = 40, Maximum = 300, Value = 120,
+            Width   = 180,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            [ToolTip.TipProperty] = "Tempo (BPM)"
+        };
+        _bpmLabel = new TextBlock
+        {
+            Text  = "120 BPM", Width = 60,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center, FontSize = 12
+        };
+        _bpmSlider.PropertyChanged += (_, e) =>
+        {
+            if (e.Property != Slider.ValueProperty) return;
+            _bpmLabel.Text = $"{_bpmSlider.Value:F0} BPM";
+            if (_player == null) return;
+            _bpmDebCts?.Cancel();
+            _bpmDebCts = new CancellationTokenSource();
+            var ct = _bpmDebCts.Token;
+            Task.Delay(300, ct).ContinueWith(_ =>
+            {
+                if (!ct.IsCancellationRequested)
+                    Dispatcher.UIThread.Post(() => { if (_player != null) StartPlayer((int)(_measureSlider?.Value ?? 1), _bpmSlider.Value); });
+            }, TaskScheduler.Default);
+        };
+
+        if (_opts.ShowMeasureSlider)
+        {
+            _measureSlider = new Slider
+            {
+                Minimum = 1, Maximum = 1, Value = _opts.StartMeasure,
+                Width   = 260,
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+                [ToolTip.TipProperty] = "Jump to measure (drag to seek)"
+            };
+            _measureLabel = new TextBlock
+            {
+                Text = "M 1/1", Width = 72,
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center, FontSize = 12
+            };
+            _measureSlider.PropertyChanged += OnMeasureSliderChanged;
+        }
+
+        _rhChk = new CheckBox
+        {
+            Content = "RH", IsChecked = true,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Margin = new Thickness(6, 0, 2, 0),
+            Foreground = new SolidColorBrush(Color.FromRgb(64, 200, 90)),
+            [ToolTip.TipProperty] = "Enable right-hand / staff 1 (green)"
+        };
+        _lhChk = new CheckBox
+        {
+            Content = "LH", IsChecked = true,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Margin = new Thickness(2, 0, 6, 0),
+            Foreground = new SolidColorBrush(Color.FromRgb(80, 130, 230)),
+            [ToolTip.TipProperty] = "Enable left-hand / staff 2 (blue)"
+        };
+        _rhChk.IsCheckedChanged += (_, _) => ApplyMutes();
+        _lhChk.IsCheckedChanged += (_, _) => ApplyMutes();
+
+        _fluidChk = new CheckBox
+        {
+            Content   = "FluidSynth",
+            IsChecked = SheetMusicLib.AppSettings.Instance.PianoRollUseFluidSynth ?? true,
+            IsVisible = _isWindows,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Margin = new Thickness(4, 0),
+            [ToolTip.TipProperty] = "FluidSynth (better sound). Unchecked = WinMM."
+        };
+        _fluidChk.IsCheckedChanged += (_, _) =>
+        {
+            UpdateDevicePickerVisibility();
+            SheetMusicLib.AppSettings.Instance.PianoRollUseFluidSynth = _fluidChk.IsChecked == true;
+            SheetMusicLib.AppSettings.Instance.SaveLocal();
+        };
+
+        // WinMM device picker (label re-purposed as TextBlock via a plain TextBlock to save casts)
+        var midiLbl = new TextBlock
+        {
+            Text = "MIDI out:",
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Margin = new Thickness(6, 0, 2, 0),
+            IsVisible = false
+        };
+        _midiDeviceLabel_asChk = new CheckBox { IsVisible = false }; // unused; kept for field compat
+        _midiDeviceCombo = new ComboBox
+        {
+            MinWidth = 180,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 4, 0),
+            IsVisible = false,
+            [ToolTip.TipProperty] = "WinMM MIDI output device"
+        };
+        _midiDeviceCombo.ItemsSource = _winmmDevices.Select(d => d.Name).ToList();
+        if (_isWindows && _winmmDevices.Count > 0)
+        {
+            string saved = SheetMusicLib.AppSettings.Instance.PianoRollWinmmDeviceName;
+            int restoreIdx = string.IsNullOrEmpty(saved)
+                ? 0
+                : Math.Max(0, _winmmDevices.ToList().FindIndex(d => d.Name == saved));
+            _midiDeviceCombo.SelectedIndex = restoreIdx;
+        }
+        _midiDeviceCombo.SelectionChanged += (_, _) =>
+        {
+            int idx = _midiDeviceCombo.SelectedIndex;
+            string name = (idx >= 0 && idx < _winmmDevices.Count) ? _winmmDevices[idx].Name : string.Empty;
+            SheetMusicLib.AppSettings.Instance.PianoRollWinmmDeviceName = name;
+            SheetMusicLib.AppSettings.Instance.SaveLocal();
+        };
+        UpdateDevicePickerVisibility();
+
+        _logNotesChk = _opts.ShowLogNotes ? new CheckBox
+        {
+            Content = "Log notes",
+            IsChecked = _opts.LogNotesDefault == true,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Margin = new Thickness(4, 0),
+            [ToolTip.TipProperty] = "Write every NoteOn to Trace while playing"
+        } : null;
+
+        _statusBlock = new TextBlock
+        {
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            FontSize = 12, Margin = new Thickness(8, 0)
+        };
+
+        // ── assemble toolbar ──────────────────────────────────────────────
+        var toolbar = new StackPanel
+        {
+            Orientation = Avalonia.Layout.Orientation.Horizontal,
+            Margin      = new Thickness(4)
+        };
+        if (_opts.LeadingControl != null) toolbar.Children.Add(_opts.LeadingControl);
+        toolbar.Children.Add(_playPauseBtn);
+        if (_skipBtn != null)    toolbar.Children.Add(_skipBtn);
+        toolbar.Children.Add(_bpmSlider);
+        toolbar.Children.Add(_bpmLabel);
+        if (_measureSlider != null) { toolbar.Children.Add(_measureSlider); toolbar.Children.Add(_measureLabel!); }
+        toolbar.Children.Add(_lhChk);
+        toolbar.Children.Add(_rhChk);
+        toolbar.Children.Add(_fluidChk);
+        toolbar.Children.Add(midiLbl);
+        toolbar.Children.Add(_midiDeviceCombo);
+        if (_logNotesChk != null) toolbar.Children.Add(_logNotesChk);
+        toolbar.Children.Add(_statusBlock);
+
+        // ── layout ────────────────────────────────────────────────────────
+        var layout = new DockPanel();
+        DockPanel.SetDock(toolbar, Dock.Top);
+        layout.Children.Add(toolbar);
+        layout.Children.Add(_contentGrid);
+        Content = layout;
+
+        // Wire up host-window lookup when we are attached
+        AttachedToVisualTree += (_, _) =>
+            _hostWindow = this.FindAncestorOfType<Window>();
+    }
+
+    // ── public methods ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Loads and optionally auto-plays a score.  Safe to call multiple times
+    /// (stops the current player first).
+    /// </summary>
+    public void LoadScore(MxlScore score, int startMeasure = 1, bool autoPlay = true)
+    {
+        StopAll();
+        _currentScore = score;
+
+        // Rebuild canvases
+        var canvas      = new VerticalPianoRollCanvas(score);
+        var staffCanvas = StaffCanvas;    // reuse the same StaffNotationCanvas instance's type but need a fresh one
+        // Replace the StaffNotationCanvas content by building a new one and swapping
+        // (the property is readonly so we swap via the content grid)
+        var newStaff = new StaffNotationCanvas(score)
+        {
+            HeaderLine1 = StaffCanvas.HeaderLine1,
+            HeaderLine2 = StaffCanvas.HeaderLine2
+        };
+        // Update the public property via reflection trick — actually just expose a method
+        ReplaceCanvases(canvas, newStaff);
+
+        _canvas = canvas;
+
+        // Rebuild measure map
+        _totalMeasures = score.Parts.Count > 0 ? score.Parts.Max(p => p.Measures.Count) : 1;
+        _measureDivMap = score.Parts.Count > 0
+            ? score.Parts[0].Measures
+                .Select(m => (Divs: m.GlobalOnsetDivisions, m.Number))
+                .OrderBy(x => x.Divs).ToList()
+            : new List<(long, int)>();
+
+        if (_measureSlider != null)
+        {
+            _suppressMeasureSync = true;
+            _measureSlider.Maximum = Math.Max(1, _totalMeasures);
+            _measureSlider.Value   = Math.Max(1, Math.Min(startMeasure, _totalMeasures));
+            _suppressMeasureSync = false;
+            _measureLabel!.Text  = $"M {(int)_measureSlider.Value}/{_totalMeasures}";
+        }
+
+        _bpmSlider.Value = score.DefaultBpm;
+        _statusBlock.Text = $"Stopped  |  {score.Title}";
+        _playPauseBtn.Content = "▶  Play";
+
+        if (autoPlay)
+            Dispatcher.UIThread.Post(() =>
+                _playPauseBtn.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent)),
+                DispatcherPriority.Background);
+    }
+
+    /// <summary>Sets the now/next text drawn inside the staff canvas header area.</summary>
+    public void SetHeaderText(string line1, string line2 = "")
+    {
+        // Find the current StaffNotationCanvas in the grid
+        var sc = _contentGrid.Children.OfType<StaffNotationCanvas>().FirstOrDefault();
+        if (sc == null) return;
+        sc.HeaderLine1 = line1;
+        sc.HeaderLine2 = line2;
+        sc.RefreshNotes();
+    }
+
+    /// <summary>Registers a callback for the ⏭ Skip button. Only relevant when ShowSkipButton=true.</summary>
+    public void SetSkipAction(Action onSkip)
+    {
+        if (_skipBtn != null)
+            _skipBtn.Click += (_, _) => onSkip();
+    }
+
+    /// <summary>Stops playback and disposes the current player. Safe to call multiple times.</summary>
+    public void StopAll()
+    {
+        var p = _player;
+        _player = null;
+        if (_canvas != null) { _canvas.CurrentGlobalDivisions = -1; }
+        var sc = _contentGrid.Children.OfType<StaffNotationCanvas>().FirstOrDefault();
+        if (sc != null) sc.CurrentGlobalDivisions = -1;
+        if (_measureSlider != null) _measureSlider.Value = 1;
+        _playPauseBtn.Content = "▶  Play";
+        if (p != null) Task.Run(() => { try { p.Stop(); p.Dispose(); } catch { } });
+    }
+
+    // ── private helpers ───────────────────────────────────────────────────────
+
+    private void ReplaceCanvases(VerticalPianoRollCanvas canvas, StaffNotationCanvas staff)
+    {
+        _contentGrid.Children.Clear();
+        Grid.SetColumn(canvas, 0);
+        Grid.SetColumn(staff,  1);
+        _contentGrid.Children.Add(canvas);
+        _contentGrid.Children.Add(staff);
+        // Transfer mute state
+        ApplyMutesToCanvas(canvas);
+        ApplyMutesToStaff(staff);
+    }
+
+    private void ApplyMutes()
+    {
+        if (_canvas is { } cv) ApplyMutesToCanvas(cv);
+        var sc = _contentGrid.Children.OfType<StaffNotationCanvas>().FirstOrDefault();
+        if (sc != null) ApplyMutesToStaff(sc);
+        if (_player is { } pr)
+        {
+            if (_rhChk.IsChecked != true) pr.MutedStaves.Add(1); else pr.MutedStaves.Remove(1);
+            if (_lhChk.IsChecked != true) pr.MutedStaves.Add(2); else pr.MutedStaves.Remove(2);
+        }
+    }
+
+    private void ApplyMutesToCanvas(VerticalPianoRollCanvas cv)
+    {
+        if (_rhChk.IsChecked != true) cv.MutedStaves.Add(1); else cv.MutedStaves.Remove(1);
+        if (_lhChk.IsChecked != true) cv.MutedStaves.Add(2); else cv.MutedStaves.Remove(2);
+        cv.RefreshBars();
+    }
+
+    private void ApplyMutesToStaff(StaffNotationCanvas sc)
+    {
+        if (_rhChk.IsChecked != true) sc.MutedStaves.Add(1); else sc.MutedStaves.Remove(1);
+        if (_lhChk.IsChecked != true) sc.MutedStaves.Add(2); else sc.MutedStaves.Remove(2);
+        sc.RefreshNotes();
+    }
+
+    private void UpdateDevicePickerVisibility()
+    {
+        bool show = _isWindows && _fluidChk.IsChecked != true;
+        _midiDeviceCombo.IsVisible = show;
+    }
+
+    private int SelectedWinmmDeviceId()
+    {
+        int idx = _midiDeviceCombo.SelectedIndex;
+        return (idx >= 0 && idx < _winmmDevices.Count) ? _winmmDevices[idx].Id : -1;
+    }
+
+    private int DivsToMeasure(long divs)
+    {
+        int lo = 0, hi = _measureDivMap.Count - 1, result = 1;
+        while (lo <= hi)
+        {
+            int mid = (lo + hi) / 2;
+            if (_measureDivMap[mid].Divs <= divs) { result = _measureDivMap[mid].Number; lo = mid + 1; }
+            else hi = mid - 1;
+        }
+        return result;
+    }
+
+    private void SetPaused()
+    {
+        var p = _player;
+        _player = null;
+        _canvas?.FreezeAtCurrentPosition();
+        var sc = _contentGrid.Children.OfType<StaffNotationCanvas>().FirstOrDefault();
+        sc?.FreezeAtCurrentPosition();
+        int mno = (int)(_measureSlider?.Value ?? 1);
+        _statusBlock.Text = $"Paused  |  M {mno}/{_totalMeasures}  |  BPM: {_bpmSlider.Value:F0}";
+        _playPauseBtn.Content = "▶  Play";
+        if (p != null) Task.Run(() => { try { p.Stop(); p.Dispose(); } catch { } });
+    }
+
+    private void StartPlayer(int measure, double bpm)
+    {
+        if (_currentScore == null || _canvas == null) return;
+        var score = _currentScore;
+        var canvas = _canvas;
+        var sc = _contentGrid.Children.OfType<StaffNotationCanvas>().FirstOrDefault();
+
+        // Stop old player asynchronously
+        var old = _player;
+        _player = null;
+        if (old != null) Task.Run(() => { try { old.Stop(); old.Dispose(); } catch { } });
+
+        bool useFluid  = _fluidChk.IsChecked == true || !_isWindows;
+        string? sf     = useFluid ? VerticalPianoRollWindowFactory.FindSoundfont() : null;
+
+        var player = new MxlMidiPlayer(score)
+        {
+            Bpm           = bpm,
+            StartMeasure  = measure,
+            Backend       = (useFluid && sf != null) ? MidiBackendKind.FluidSynth : MidiBackendKind.Winmm,
+            SoundfontPath = sf ?? string.Empty,
+            LogNotes      = _logNotesChk?.IsChecked == true,
+            WinmmDeviceId = SelectedWinmmDeviceId(),
+        };
+        _player = player;
+        ApplyMutes();
+
+        long startDivs = measure <= 1
+            ? 0
+            : (_measureDivMap.FirstOrDefault(x => x.Number >= measure).Divs);
+        canvas.PlayBpm = bpm;
+        canvas.StartSmoothPlay(startDivs);
+        if (sc != null) { sc.PlayBpm = bpm; sc.StartSmoothPlay(startDivs); }
+
+        player.PositionChanged += (_, divs) =>
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                canvas.SyncAnchor(divs);
+                sc?.SyncAnchor(divs);
+            }, DispatcherPriority.Render);
+            Dispatcher.UIThread.Post(() =>
+            {
+                int mno = DivsToMeasure(divs);
+                if (_measureSlider != null)
+                {
+                    _suppressMeasureSync = true;
+                    if ((int)_measureSlider.Value != mno) _measureSlider.Value = mno;
+                    _suppressMeasureSync = false;
+                }
+                _statusBlock.Text = $"M {mno}/{_totalMeasures}  |  BPM: {bpm:F0}  |  {score.Title}";
+                MeasureChanged?.Invoke(this, mno);
+            }, DispatcherPriority.Normal);
+        };
+
+        player.PlaybackEnded += (_, _) =>
+            Dispatcher.UIThread.Post(() =>
+            {
+                _player = null;
+                canvas.CurrentGlobalDivisions = -1;
+                if (sc != null) sc.CurrentGlobalDivisions = -1;
+                if (_measureSlider != null) _measureSlider.Value = 1;
+                _statusBlock.Text = $"Stopped  |  {score.Title}";
+                _playPauseBtn.Content = "▶  Play";
+                PlaybackEnded?.Invoke(this, EventArgs.Empty);
+                if (_opts.AutoCloseOnEnd) _hostWindow?.Close();
+            }, DispatcherPriority.Normal);
+
+        _statusBlock.Text = $"Playing  |  BPM: {bpm:F0}  |  {score.Title}";
+        _playPauseBtn.Content = "⏸  Pause";
+        player.Start();
+    }
+
+    private void OnPlayPauseClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (_player != null) { SetPaused(); return; }
+        StartPlayer((int)(_measureSlider?.Value ?? 1), _bpmSlider.Value);
+    }
+
+    private void OnMeasureSliderChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property != Slider.ValueProperty || _measureSlider == null) return;
+        int mno = (int)_measureSlider.Value;
+        if (_measureLabel != null) _measureLabel.Text = $"M {mno}/{_totalMeasures}";
+
+        if (_player == null && _canvas != null)
+        {
+            long previewDivs = mno <= 1 ? 0 : (_measureDivMap.FirstOrDefault(x => x.Number >= mno).Divs);
+            _canvas.CurrentGlobalDivisions = previewDivs;
+            var sc = _contentGrid.Children.OfType<StaffNotationCanvas>().FirstOrDefault();
+            if (sc != null) sc.CurrentGlobalDivisions = previewDivs;
+        }
+
+        if (_suppressMeasureSync || _player == null) return;
+        _measureDebCts?.Cancel();
+        _measureDebCts = new CancellationTokenSource();
+        var ct = _measureDebCts.Token;
+        Task.Delay(200, ct).ContinueWith(_ =>
+        {
+            if (!ct.IsCancellationRequested)
+                Dispatcher.UIThread.Post(() => { if (_player != null) StartPlayer((int)_measureSlider.Value, _bpmSlider.Value); });
+        }, TaskScheduler.Default);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  VerticalPianoRollWindowFactory  — static factory
 /// <summary>
 /// Static factory for building the vertical piano roll <see cref="Window"/>.
 /// Call <see cref="BuildWindow"/> to create a fully wired-up window that auto-starts
@@ -1840,399 +2402,35 @@ public static class VerticalPianoRollWindowFactory
     {
         VerticalPianoRollCanvas.SyncDiagnostics = syncDiagnostics;
         MxlMidiPlayer.TimingDiagnostics         = syncDiagnostics;
-        var canvas      = new VerticalPianoRollCanvas(score);
-        var staffCanvas = new StaffNotationCanvas(score);
-        var statusBlock = new TextBlock
+
+        var player = new PianoRollPlayerControl(new PianoRollOptions
         {
-            Text = $"Stopped  |  BPM: {score.DefaultBpm:F0}  |  {score.Title}",
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            FontSize = 12,
-            Margin = new Thickness(8, 0)
-        };
-
-        var bpmSlider = new Slider
-        {
-            Minimum = 40, Maximum = 300,
-            Value   = score.DefaultBpm,
-            Width   = 180,
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            [ToolTip.TipProperty] = "Tempo (BPM)"
-        };
-        var bpmLabel = new TextBlock
-        {
-            Text = $"{score.DefaultBpm:F0} BPM",
-            Width = 60,
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            FontSize = 12
-        };
-        bpmSlider.PropertyChanged += (_, e) =>
-        {
-            if (e.Property == Slider.ValueProperty)
-                bpmLabel.Text = $"{bpmSlider.Value:F0} BPM";
-        };
-
-        var playStopBtn = new Button { Content = "▶  Play", Margin = new Thickness(4), Padding = new Thickness(8, 2) };
-        // NOTE: live-playback BPM debounce and measure-seek handlers are wired below, after StartPlayer is defined.
-
-        int totalMeasures = score.Parts.Count > 0 ? score.Parts.Max(p => p.Measures.Count) : 1;
-        var measureSlider = new Slider
-        {
-            Minimum = 1, Maximum = Math.Max(1, totalMeasures),
-            Value   = Math.Max(1, startMeasure),
-            Width   = 260,
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            [ToolTip.TipProperty] = "Jump to measure (drag to seek)"
-        };
-        var measureLabel = new TextBlock
-        {
-            Text = $"M 1/{totalMeasures}",
-            Width = 72,
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            FontSize = 12
-        };
-        measureSlider.PropertyChanged += (_, e) =>
-        {
-            if (e.Property == Slider.ValueProperty)
-                measureLabel.Text = $"M {(int)measureSlider.Value}/{totalMeasures}";
-        };
-        // NOTE: live seek handler wired below, after StartPlayer is defined.
-
-        bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-        var fluidSynthChk = new CheckBox
-        {
-            Content = "FluidSynth",
-            IsChecked = SheetMusicLib.AppSettings.Instance.PianoRollUseFluidSynth ?? true,
-            IsVisible = isWindows,   // Non-Windows: always FluidSynth, checkbox not needed
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            Margin = new Thickness(4, 0),
-            [ToolTip.TipProperty] = "FluidSynth (better sound). Unchecked = WinMM (Windows MIDI, no extra dependencies)."
-        };
-
-        // ── WinMM MIDI output device picker ────────────────────────────────────────────
-        // Only shown on Windows when FluidSynth is unchecked.
-        var midiDeviceLabel = new TextBlock
-        {
-            Text = "MIDI out:",
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            Margin = new Thickness(6, 0, 2, 0),
-            IsVisible = false,
-        };
-        var midiDeviceCombo = new ComboBox
-        {
-            MinWidth = 180,
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            Margin = new Thickness(0, 0, 4, 0),
-            IsVisible = false,
-            [ToolTip.TipProperty] = "WinMM MIDI output device",
-        };
-
-        // Populate the device list (Windows only).
-        var winmmDevices = isWindows ? WinmmMidiBackend.EnumerateDevices() : [];
-        midiDeviceCombo.ItemsSource = winmmDevices.Select(d => d.Name).ToList();
-
-        // Restore the previously saved device by name (name is stable; index can shift).
-        if (isWindows && winmmDevices.Count > 0)
-        {
-            string saved = SheetMusicLib.AppSettings.Instance.PianoRollWinmmDeviceName;
-            int restoreIdx = string.IsNullOrEmpty(saved)
-                ? 0
-                : Math.Max(0, winmmDevices.ToList().FindIndex(d => d.Name == saved));
-            midiDeviceCombo.SelectedIndex = restoreIdx;
-        }
-
-        // Persist device choice whenever the user changes the selection.
-        midiDeviceCombo.SelectionChanged += (_, _) =>
-        {
-            int idx = midiDeviceCombo.SelectedIndex;
-            string name = (idx >= 0 && idx < winmmDevices.Count) ? winmmDevices[idx].Name : string.Empty;
-            SheetMusicLib.AppSettings.Instance.PianoRollWinmmDeviceName = name;
-            SheetMusicLib.AppSettings.Instance.SaveLocal();
-        };
-
-        void UpdateDevicePickerVisibility()
-        {
-            bool showPicker = isWindows && fluidSynthChk.IsChecked != true;
-            midiDeviceLabel.IsVisible = showPicker;
-            midiDeviceCombo.IsVisible = showPicker;
-        }
-        fluidSynthChk.IsCheckedChanged += (_, _) =>
-        {
-            UpdateDevicePickerVisibility();
-            SheetMusicLib.AppSettings.Instance.PianoRollUseFluidSynth = fluidSynthChk.IsChecked == true;
-            SheetMusicLib.AppSettings.Instance.SaveLocal();
-        };
-        UpdateDevicePickerVisibility();
-
-        int SelectedWinmmDeviceId() =>
-            (midiDeviceCombo.SelectedIndex >= 0 && midiDeviceCombo.SelectedIndex < winmmDevices.Count)
-                ? winmmDevices[midiDeviceCombo.SelectedIndex].Id
-                : -1;
-
-        var logNotesChk = new CheckBox
-        {
-            Content = "Log notes",
-            IsChecked = logNotesDefault,
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            Margin = new Thickness(4, 0),
-            [ToolTip.TipProperty] = "Write every NoteOn to Trace while playing"
-        };
-
-        // Build a sorted lookup: global-division onset -> measure number (for live slider sync)
-        var measureDivMap = score.Parts.Count > 0
-            ? score.Parts[0].Measures
-                .Select(m => (Divs: m.GlobalOnsetDivisions, m.Number))
-                .OrderBy(x => x.Divs)
-                .ToList()
-            : new List<(long Divs, int Number)>();
-
-        int DivsToMeasure(long divs)
-        {
-            int lo = 0, hi = measureDivMap.Count - 1, result = 1;
-            while (lo <= hi)
-            {
-                int mid = (lo + hi) / 2;
-                if (measureDivMap[mid].Divs <= divs) { result = measureDivMap[mid].Number; lo = mid + 1; }
-                else hi = mid - 1;
-            }
-            return result;
-        }
-
-        MxlMidiPlayer? player = null;
-        Window?[] windowHolder = [null];
-
-        void SetStopped()
-        {
-            var playerToStop = player;
-            player = null;
-            canvas.CurrentGlobalDivisions      = -1;
-            staffCanvas.CurrentGlobalDivisions = -1;
-            measureSlider.Value = score.Parts.Count > 0 ? 1 : 0;
-            statusBlock.Text = $"Stopped  |  {score.Title}";
-            playStopBtn.Content = "▶  Play";
-            if (playerToStop != null)
-                Task.Run(() => { try { playerToStop.Stop(); playerToStop.Dispose(); } catch { } });
-        }
-
-        void SetPaused()
-        {
-            var playerToStop = player;
-            player = null;
-            // Freeze the visual exactly where it is — resume restarts from there.
-            canvas.FreezeAtCurrentPosition();
-            staffCanvas.FreezeAtCurrentPosition();
-            int mno = (int)measureSlider.Value;
-            statusBlock.Text = $"Paused  |  M {mno}/{totalMeasures}  |  BPM: {bpmSlider.Value:F0}  |  {score.Title}";
-            playStopBtn.Content = "▶  Play";
-            if (playerToStop != null)
-                Task.Run(() => { try { playerToStop.Stop(); playerToStop.Dispose(); } catch { } });
-        }
-
-        // True while PositionChanged is updating the slider to suppress the seek-on-change handler.
-        bool suppressMeasureSliderSync = false;
-
-        void StartPlayer(int measure, double bpm)
-        {
-            // Stop the currently running player asynchronously so the new one can start immediately.
-            var playerToStop = player;
-            player = null;
-            if (playerToStop != null)
-                Task.Run(() => { try { playerToStop.Stop(); playerToStop.Dispose(); } catch { } });
-
-            bool useFluid = fluidSynthChk.IsChecked == true || !isWindows;
-            string? sf = useFluid ? FindSoundfont() : null;
-            player = new MxlMidiPlayer(score)
-            {
-                Bpm           = bpm,
-                StartMeasure  = measure,
-                Backend       = (useFluid && sf != null) ? MidiBackendKind.FluidSynth : MidiBackendKind.Winmm,
-                SoundfontPath = sf ?? string.Empty,
-                LogNotes      = logNotesChk.IsChecked == true,
-                WinmmDeviceId = SelectedWinmmDeviceId(),
-            };
-            if (useFluid && sf == null)
-                Trace.WriteLine("VerticalPianoRoll: no soundfont found -- falling back to WinMM");
-
-            canvas.PlayBpm      = bpm;
-            staffCanvas.PlayBpm = bpm;
-
-            long startDivisions = measure <= 1
-                ? 0
-                : (measureDivMap.FirstOrDefault(x => x.Number >= measure).Divs);
-            canvas.StartSmoothPlay(startDivisions);
-            staffCanvas.StartSmoothPlay(startDivisions);
-
-            player.PositionChanged += (_, divs) =>
-            {
-                // High-priority post for the one-time clock sync; normal post for UI updates.
-                Dispatcher.UIThread.Post(() =>
-                {
-                    canvas.SyncAnchor(divs);
-                    staffCanvas.SyncAnchor(divs);
-                }, DispatcherPriority.Render);
-                Dispatcher.UIThread.Post(() =>
-                {
-                    int mno = DivsToMeasure(divs);
-                    suppressMeasureSliderSync = true;
-                    if ((int)measureSlider.Value != mno)
-                        measureSlider.Value = mno;
-                    suppressMeasureSliderSync = false;
-                    statusBlock.Text = $"M {mno}/{totalMeasures}  |  BPM: {bpm:F0}  |  {score.Title}";
-                }, DispatcherPriority.Normal);
-            };
-
-            player.PlaybackEnded += (_, _) =>
-                Dispatcher.UIThread.Post(() =>
-                {
-                    SetStopped();
-                    if (autoCloseOnEnd) windowHolder[0]?.Close();
-                }, DispatcherPriority.Normal);
-
-            statusBlock.Text = $"Playing  |  BPM: {bpm:F0}  |  {score.Title}";
-            playStopBtn.Content = "⏸  Pause";
-            player.Start();
-            foreach (var s in canvas.MutedStaves) player.MutedStaves.Add(s);
-        }
-
-        playStopBtn.Click += (_, _) =>
-        {
-            // If playing -> pause (preserves position; click again to resume)
-            if (player != null) { SetPaused(); return; }
-
-            // Stopped or paused -> start / resume from current measure
-            StartPlayer((int)measureSlider.Value, bpmSlider.Value);
-        };
-
-        // ── Live-playback slider wiring ────────────────────────────────────────────────
-        // Both handlers live here so StartPlayer, player, suppressMeasureSliderSync etc.
-        // are all already declared above.
-        CancellationTokenSource? bpmDebounceCts     = null;
-        CancellationTokenSource? measureDebounceCts = null;
-
-        bpmSlider.PropertyChanged += (_, e) =>
-        {
-            if (e.Property != Slider.ValueProperty) return;
-            bpmLabel.Text = $"{bpmSlider.Value:F0} BPM";
-            if (player == null) return;
-            // Debounce: restart audio only after the slider has been idle for 300 ms.
-            bpmDebounceCts?.Cancel();
-            bpmDebounceCts = new CancellationTokenSource();
-            var ct = bpmDebounceCts.Token;
-            Task.Delay(300, ct).ContinueWith(_ =>
-            {
-                if (!ct.IsCancellationRequested)
-                    Dispatcher.UIThread.Post(() => { if (player != null) StartPlayer((int)measureSlider.Value, bpmSlider.Value); });
-            }, TaskScheduler.Default);
-        };
-
-        measureSlider.PropertyChanged += (_, e) =>
-        {
-            if (e.Property != Slider.ValueProperty) return;
-            int mno = (int)measureSlider.Value;
-            measureLabel.Text = $"M {mno}/{totalMeasures}";
-
-            // When stopped or paused (player == null) the animation timer is idle, so we can
-            // drive the canvas directly from the slider for instant visual preview.
-            // Skip this when playing — the timer owns the position and will overwrite it anyway.
-            if (player == null)
-            {
-                long previewDivs = mno <= 1
-                    ? 0
-                    : (measureDivMap.FirstOrDefault(x => x.Number >= mno).Divs);
-                canvas.CurrentGlobalDivisions      = previewDivs;
-                staffCanvas.CurrentGlobalDivisions = previewDivs;
-            }
-
-            if (suppressMeasureSliderSync || player == null) return;
-            // Debounce: seek only after the slider has been idle for 200 ms.
-            measureDebounceCts?.Cancel();
-            measureDebounceCts = new CancellationTokenSource();
-            var ct = measureDebounceCts.Token;
-            Task.Delay(200, ct).ContinueWith(_ =>
-            {
-                if (!ct.IsCancellationRequested)
-                    Dispatcher.UIThread.Post(() => { if (player != null) StartPlayer((int)measureSlider.Value, bpmSlider.Value); });
-            }, TaskScheduler.Default);
-        };
-
-        // ── Part mute checkboxes
-        // Staff 1 = RH (green), staff 2 = LH (blue).  Wired to both canvas and player.
-        var rhChk = new CheckBox
-        {
-            Content           = "RH",
-            IsChecked         = true,
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            Margin            = new Thickness(6, 0, 2, 0),
-            Foreground        = new SolidColorBrush(Color.FromRgb(64, 200, 90)),
-            [ToolTip.TipProperty] = "Enable right-hand / staff 1 (green)"
-        };
-        var lhChk = new CheckBox
-        {
-            Content           = "LH",
-            IsChecked         = true,
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            Margin            = new Thickness(2, 0, 6, 0),
-            Foreground        = new SolidColorBrush(Color.FromRgb(80, 130, 230)),
-            [ToolTip.TipProperty] = "Enable left-hand / staff 2 (blue)"
-        };
-
-        void ApplyMutes()
-        {
-            bool rhOn = rhChk.IsChecked == true;
-            bool lhOn = lhChk.IsChecked == true;
-            if (!rhOn) canvas.MutedStaves.Add(1); else canvas.MutedStaves.Remove(1);
-            if (!lhOn) canvas.MutedStaves.Add(2); else canvas.MutedStaves.Remove(2);
-            canvas.RefreshBars();
-            if (!rhOn) staffCanvas.MutedStaves.Add(1); else staffCanvas.MutedStaves.Remove(1);
-            if (!lhOn) staffCanvas.MutedStaves.Add(2); else staffCanvas.MutedStaves.Remove(2);
-            staffCanvas.RefreshNotes();
-            if (player != null)
-            {
-                if (!rhOn) player.MutedStaves.Add(1); else player.MutedStaves.Remove(1);
-                if (!lhOn) player.MutedStaves.Add(2); else player.MutedStaves.Remove(2);
-            }
-        }
-        rhChk.IsCheckedChanged += (_, _) => ApplyMutes();
-        lhChk.IsCheckedChanged += (_, _) => ApplyMutes();
-
-        var toolbar = new StackPanel
-        {
-            Orientation = Avalonia.Layout.Orientation.Horizontal,
-            Margin      = new Thickness(4),
-            Children    = { playStopBtn, bpmSlider, bpmLabel, measureSlider, measureLabel, lhChk, rhChk, fluidSynthChk, midiDeviceLabel, midiDeviceCombo, logNotesChk, statusBlock }
-        };
-
-        var layout = new DockPanel();
-        DockPanel.SetDock(toolbar, Dock.Top);
-        layout.Children.Add(toolbar);
-
-        var contentGrid = new Grid();
-        contentGrid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-        contentGrid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
-        Grid.SetColumn(canvas,      0);
-        Grid.SetColumn(staffCanvas, 1);
-        contentGrid.Children.Add(canvas);
-        contentGrid.Children.Add(staffCanvas);
-        layout.Children.Add(contentGrid);
+            StartMeasure      = startMeasure,
+            AutoCloseOnEnd    = autoCloseOnEnd,
+            ShowMeasureSlider = true,
+            ShowLogNotes      = true,
+            ShowSkipButton    = false,
+            LogNotesDefault   = logNotesDefault,
+        });
 
         var window = new Window
         {
-            Title  = $"Vertical Piano Roll — {Path.GetFileName(mxlPath)}",
-            Width  = 1400,
-            Height = 720,
-            WindowState = WindowState.Maximized,
+            Title                 = $"Vertical Piano Roll — {Path.GetFileName(mxlPath)}",
+            Width                 = 1400,
+            Height                = 720,
+            WindowState           = WindowState.Maximized,
             WindowStartupLocation = WindowStartupLocation.CenterScreen,
-            ShowInTaskbar = false,
-            Content = layout
+            ShowInTaskbar         = false,
+            Content               = player,
         };
-        windowHolder[0] = window;
-        window.Closed += (_, _) => SetStopped();
+        window.Closed += (_, _) => player.StopAll();
 
         bool autoPlayFired = false;
         window.Opened += (_, _) =>
         {
             if (autoPlayFired) return;
             autoPlayFired = true;
-            playStopBtn.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+            player.LoadScore(score, startMeasure, autoPlay: true);
         };
         return window;
     }
@@ -2267,232 +2465,31 @@ public static class VerticalPianoRollWindowFactory
         string windowTitle,
         IReadOnlyList<MusicPatternInfo> patterns)
     {
-        // ── initial score (first entry) ───────────────────────────────────
-        var firstPattern = patterns[0];
-        var score        = firstPattern.Build();
-
-        // Canvas and player state
-        var canvasHolder = new Control?[1];
-        var staffHolder  = new StaffNotationCanvas?[1];
-        var playerHolder = new MxlMidiPlayer?[1];
-        var windowHolder = new Window?[1];
-
-        void StopPlayer()
-        {
-            playerHolder[0]?.Stop();
-            playerHolder[0] = null;
-        }
-
-        // ── toolbar controls ──────────────────────────────────────────────
         var patternCombo = new ComboBox
         {
-            Width                = 320,
-            VerticalAlignment    = Avalonia.Layout.VerticalAlignment.Center,
+            Width                 = 320,
+            VerticalAlignment     = Avalonia.Layout.VerticalAlignment.Center,
             [ToolTip.TipProperty] = "Select a pattern",
         };
-        patternCombo.ItemsSource    = patterns;
-        patternCombo.SelectedIndex  = 0;
-        patternCombo.ItemTemplate   = new Avalonia.Controls.Templates.FuncDataTemplate<MusicPatternInfo>(
+        patternCombo.ItemsSource   = patterns;
+        patternCombo.SelectedIndex = 0;
+        patternCombo.ItemTemplate  = new Avalonia.Controls.Templates.FuncDataTemplate<MusicPatternInfo>(
             (info, _) => new TextBlock { Text = info.Display });
 
-        var statusBlock = new TextBlock
+        var player = new PianoRollPlayerControl(new PianoRollOptions
         {
-            Text              = $"Stopped  |  BPM: {score.DefaultBpm:F0}  |  {score.Title}",
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            FontSize          = 12,
-            Margin            = new Thickness(8, 0)
-        };
+            ShowMeasureSlider = false,
+            ShowLogNotes      = false,
+            ShowSkipButton    = false,
+            LeadingControl    = patternCombo,
+        });
 
-        var bpmSlider = new Slider
-        {
-            Minimum = 40, Maximum = 300, Value = score.DefaultBpm,
-            Width   = 180,
-            VerticalAlignment    = Avalonia.Layout.VerticalAlignment.Center,
-            [ToolTip.TipProperty] = "Tempo (BPM)"
-        };
-        var bpmLabel = new TextBlock
-        {
-            Text = $"{score.DefaultBpm:F0} BPM", Width = 60,
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center, FontSize = 12
-        };
-        bpmSlider.PropertyChanged += (_, e) =>
-        {
-            if (e.Property == Slider.ValueProperty)
-                bpmLabel.Text = $"{bpmSlider.Value:F0} BPM";
-        };
-
-        var playStopBtn = new Button
-        {
-            Content = "▶  Play",
-            Margin  = new Thickness(4),
-            Padding = new Thickness(8, 2)
-        };
-
-        bool isWindows    = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-        var fluidSynthChk = new CheckBox
-        {
-            Content           = "FluidSynth",
-            IsChecked         = !isWindows,
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            Margin            = new Thickness(4, 0),
-            [ToolTip.TipProperty] = "Use FluidSynth (cross-platform); uncheck for WinMM (Windows only)"
-        };
-
-        // ── content grid: piano roll left, staff notation right ─────────
-        var contentGrid = new Grid();
-        contentGrid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-        contentGrid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
-
-        // ── Part mute checkboxes (declared here so LoadPattern can call ApplyMutesP) ──
-        var rhChkP = new CheckBox
-        {
-            Content           = "RH",
-            IsChecked         = true,
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            Margin            = new Thickness(6, 0, 2, 0),
-            Foreground        = new SolidColorBrush(Color.FromRgb(64, 200, 90)),
-            [ToolTip.TipProperty] = "Enable right-hand / staff 1 (green)"
-        };
-        var lhChkP = new CheckBox
-        {
-            Content           = "LH",
-            IsChecked         = true,
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            Margin            = new Thickness(2, 0, 6, 0),
-            Foreground        = new SolidColorBrush(Color.FromRgb(80, 130, 230)),
-            [ToolTip.TipProperty] = "Enable left-hand / staff 2 (blue)"
-        };
-
-        void ApplyMutesP()
-        {
-            bool rhOn = rhChkP.IsChecked == true;
-            bool lhOn = lhChkP.IsChecked == true;
-            if (canvasHolder[0] is VerticalPianoRollCanvas cv)
-            {
-                if (!rhOn) cv.MutedStaves.Add(1); else cv.MutedStaves.Remove(1);
-                if (!lhOn) cv.MutedStaves.Add(2); else cv.MutedStaves.Remove(2);
-                cv.RefreshBars();
-            }
-            if (staffHolder[0] is StaffNotationCanvas sc)
-            {
-                if (!rhOn) sc.MutedStaves.Add(1); else sc.MutedStaves.Remove(1);
-                if (!lhOn) sc.MutedStaves.Add(2); else sc.MutedStaves.Remove(2);
-                sc.RefreshNotes();
-            }
-            if (playerHolder[0] is MxlMidiPlayer pr)
-            {
-                if (!rhOn) pr.MutedStaves.Add(1); else pr.MutedStaves.Remove(1);
-                if (!lhOn) pr.MutedStaves.Add(2); else pr.MutedStaves.Remove(2);
-            }
-        }
-        rhChkP.IsCheckedChanged += (_, _) => ApplyMutesP();
-        lhChkP.IsCheckedChanged += (_, _) => ApplyMutesP();
-
-        void LoadPattern(MusicPatternInfo info)
-        {
-            StopPlayer();
-            var s = info.Build();
-
-            // Rebuild both canvases with the new score
-            contentGrid.Children.Clear();
-            var newCanvas = new VerticalPianoRollCanvas(s);
-            var newStaff  = new StaffNotationCanvas(s);
-            Grid.SetColumn(newCanvas, 0);
-            Grid.SetColumn(newStaff,  1);
-            canvasHolder[0] = newCanvas;
-            staffHolder[0]  = newStaff;
-            contentGrid.Children.Add(newCanvas);
-            contentGrid.Children.Add(newStaff);
-
-            bpmSlider.Value = s.DefaultBpm;
-            patternCombo[ToolTip.TipProperty] = info.Tooltip;
-            statusBlock.Text     = $"Stopped  |  BPM: {s.DefaultBpm:F0}  |  {s.Title}";
-            playStopBtn.Content  = "▶  Play";
-
-            ApplyMutesP();
-
-            // Auto-play
-            Dispatcher.UIThread.Post(() =>
-                playStopBtn.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent)),
-                DispatcherPriority.Background);
-        }
-
+        // Load new pattern whenever the combo selection changes.
         patternCombo.SelectionChanged += (_, _) =>
         {
             if (patternCombo.SelectedItem is MusicPatternInfo info)
-                LoadPattern(info);
+                player.LoadScore(info.Build(), autoPlay: true);
         };
-
-        // ── play/stop wiring ──────────────────────────────────────────────
-        playStopBtn.Click += (_, _) =>
-        {
-            if (playerHolder[0] != null) { StopPlayer(); playStopBtn.Content = "▶  Play"; return; }
-
-            if (patternCombo.SelectedItem is not MusicPatternInfo info) return;
-            var s = info.Build();
-
-            bool useFluid = fluidSynthChk.IsChecked == true || !isWindows;
-            string? sf    = useFluid ? FindSoundfont() : null;
-            var p = new MxlMidiPlayer(s)
-            {
-                Bpm           = bpmSlider.Value,
-                StartMeasure  = 1,
-                Backend       = (useFluid && sf != null) ? MidiBackendKind.FluidSynth : MidiBackendKind.Winmm,
-                SoundfontPath = sf ?? string.Empty,
-            };
-            playerHolder[0] = p;
-            // Apply current mute state before playback starts
-            ApplyMutesP();
-
-            p.PositionChanged += (_, divs) =>
-                Dispatcher.UIThread.Post(() =>
-                {
-                    if (canvasHolder[0] is VerticalPianoRollCanvas c)
-                        c.CurrentGlobalDivisions = divs;
-                    if (staffHolder[0] is StaffNotationCanvas sc)
-                        sc.CurrentGlobalDivisions = divs;
-                    statusBlock.Text = $"Playing  |  BPM: {bpmSlider.Value:F0}  |  {s.Title}";
-                }, DispatcherPriority.Render);
-
-            p.PlaybackEnded += (_, _) =>
-                Dispatcher.UIThread.Post(() =>
-                {
-                    var old = playerHolder[0];
-                    playerHolder[0] = null;
-                    if (canvasHolder[0] is VerticalPianoRollCanvas cv)
-                        cv.CurrentGlobalDivisions = -1;
-                    if (staffHolder[0] is StaffNotationCanvas sc)
-                        sc.CurrentGlobalDivisions = -1;
-                    playStopBtn.Content = "▶  Play";
-                    statusBlock.Text    = $"Stopped  |  BPM: {bpmSlider.Value:F0}  |  {s.Title}";
-                    if (old != null) Task.Run(() => { try { old.Stop(); } catch { } });
-                }, DispatcherPriority.Normal);
-
-            playStopBtn.Content = "■  Stop";
-            p.Start();
-        };
-
-        // ── initial canvas + staff ─────────────────────────────────────────
-        var initialCanvas = new VerticalPianoRollCanvas(score);
-        var initialStaff  = new StaffNotationCanvas(score);
-        Grid.SetColumn(initialCanvas, 0);
-        Grid.SetColumn(initialStaff,  1);
-        canvasHolder[0] = initialCanvas;
-        staffHolder[0]  = initialStaff;
-        contentGrid.Children.Add(initialCanvas);
-        contentGrid.Children.Add(initialStaff);
-
-        var toolbar = new StackPanel
-        {
-            Orientation = Avalonia.Layout.Orientation.Horizontal,
-            Margin      = new Thickness(4),
-            Children    = { patternCombo, playStopBtn, bpmSlider, bpmLabel, lhChkP, rhChkP, fluidSynthChk, statusBlock }
-        };
-
-        var layout = new DockPanel();
-        DockPanel.SetDock(toolbar, Dock.Top);
-        layout.Children.Add(toolbar);
-        layout.Children.Add(contentGrid);
 
         var window = new Window
         {
@@ -2502,18 +2499,142 @@ public static class VerticalPianoRollWindowFactory
             WindowState           = WindowState.Maximized,
             WindowStartupLocation = WindowStartupLocation.CenterScreen,
             ShowInTaskbar         = false,
-            Content               = layout,
+            Content               = player,
         };
-        windowHolder[0] = window;
-        window.Closed += (_, _) => StopPlayer();
+        window.Closed += (_, _) => player.StopAll();
 
-        // Auto-play first pattern on open
-        bool autoPlayFired2 = false;
+        bool autoPlayFired = false;
         window.Opened += (_, _) =>
         {
-            if (autoPlayFired2) return;
-            autoPlayFired2 = true;
-            playStopBtn.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+            if (autoPlayFired) return;
+            autoPlayFired = true;
+            player.LoadScore(patterns[0].Build(), autoPlay: true);
+        };
+
+        return window;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    //  Player-piano playlist window
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Extracts the score XML from a .mxl ZIP to a temp file.
+    /// Returns the path unchanged if the file is already a plain .xml / .musicxml.
+    /// </summary>
+    public static string ResolveMxlToXml(string mxlPath)
+    {
+        if (!mxlPath.EndsWith(".mxl", StringComparison.OrdinalIgnoreCase))
+            return mxlPath;
+
+        using var zip = System.IO.Compression.ZipFile.OpenRead(mxlPath);
+        var scoreEntry = zip.Entries.FirstOrDefault(e =>
+            e.FullName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase) &&
+            !e.FullName.StartsWith("META-INF", StringComparison.OrdinalIgnoreCase));
+        if (scoreEntry == null)
+            throw new InvalidOperationException($"No score XML entry found inside {mxlPath}");
+
+        string tmpPath = Path.Combine(
+            Path.GetTempPath(),
+            Path.GetFileNameWithoutExtension(mxlPath) + "_score.xml");
+        using var stream = scoreEntry.Open();
+        using var fs     = File.Create(tmpPath);
+        stream.CopyTo(fs);
+        return tmpPath;
+    }
+
+    /// <summary>
+    /// Builds a "player piano" window that plays each song in <paramref name="songs"/>
+    /// sequentially.  When a song finishes, the next one loads and starts automatically.
+    /// A header bar shows the current song title and the next song up.
+    /// </summary>
+    /// <param name="songs">
+    /// Ordered list of <c>(mxlPath, title)</c> pairs.
+    /// <c>mxlPath</c> may be a .mxl ZIP or a plain .xml / .musicxml file.
+    /// </param>
+    public static Window BuildPlaylistWindow(IReadOnlyList<(string mxlPath, string title)> songs)
+    {
+        if (songs.Count == 0)
+            throw new ArgumentException("Song list must not be empty.", nameof(songs));
+
+        int currentIndex = 0;
+
+        var player = new PianoRollPlayerControl(new PianoRollOptions
+        {
+            ShowMeasureSlider = true,
+            ShowLogNotes      = false,
+            ShowSkipButton    = true,
+            AutoCloseOnEnd    = false,
+        });
+
+        void UpdateHeader()
+        {
+            string now  = songs[currentIndex].title;
+            string next = currentIndex + 1 < songs.Count
+                ? $"Next: {songs[currentIndex + 1].title}"
+                : "Last song";
+            player.SetHeaderText(now, next);
+        }
+
+        void LoadSong(int index)
+        {
+            if (index < 0 || index >= songs.Count) return;
+            currentIndex = index;
+
+            try
+            {
+                string xmlPath = ResolveMxlToXml(songs[index].mxlPath);
+                var score      = MxlScore.Parse(File.ReadAllText(xmlPath));
+                UpdateHeader();
+                player.LoadScore(score, autoPlay: true);
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"BuildPlaylistWindow: failed to load song {index}: {ex.Message}");
+                LoadSong(index + 1);
+            }
+        }
+
+        // Skip button advances to the next song (or closes when exhausted).
+        Window?[] windowRef = [null];
+        player.SetSkipAction(() =>
+        {
+            int next = currentIndex + 1;
+            if (next < songs.Count)
+                LoadSong(next);
+            else
+                windowRef[0]?.Close();
+        });
+
+        // Auto-advance when a song ends.
+        player.PlaybackEnded += (_, _) =>
+        {
+            int next = currentIndex + 1;
+            if (next < songs.Count)
+                Dispatcher.UIThread.Post(() => LoadSong(next), DispatcherPriority.Normal);
+            else
+                Dispatcher.UIThread.Post(() => windowRef[0]?.Close(), DispatcherPriority.Normal);
+        };
+
+        var window = new Window
+        {
+            Title                 = $"🎹 PianoRoll Playlist — {songs.Count} songs",
+            Width                 = 1400,
+            Height                = 720,
+            WindowState           = WindowState.Maximized,
+            WindowStartupLocation = WindowStartupLocation.CenterScreen,
+            ShowInTaskbar         = false,
+            Content               = player,
+        };
+        windowRef[0] = window;
+        window.Closed += (_, _) => player.StopAll();
+
+        bool autoPlayFired = false;
+        window.Opened += (_, _) =>
+        {
+            if (autoPlayFired) return;
+            autoPlayFired = true;
+            LoadSong(0);
         };
 
         return window;

--- a/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
+++ b/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
@@ -111,6 +111,7 @@ public sealed class MxlScore
             string currentTimeSig     = string.Empty;
             string currentKeySig      = string.Empty;
             int    divisions          = 1;
+            int    canonicalDivs      = 0;   // set from first <divisions> seen; all globalOnset values use this unit
             long   globalOnset        = 0;
             double globalOnsetMs      = 0.0;
             int    currentTSBeats     = 4;
@@ -123,7 +124,15 @@ public sealed class MxlScore
 
                 var divsEl = measureEl.Descendants(ns + "divisions").FirstOrDefault();
                 if (divsEl != null && int.TryParse(divsEl.Value, out var newDivs) && newDivs > 0)
+                {
                     divisions = newDivs;
+                    if (canonicalDivs == 0) canonicalDivs = newDivs;   // lock canonical unit to first value
+                }
+                // Normalise all tick values to the canonical unit (first <divisions> seen).
+                // Use rational multiply-then-divide so both increases (4→12) and
+                // decreases (24→2) are handled correctly without integer truncation to zero.
+                int scaleMul = canonicalDivs > 0 ? canonicalDivs : 1;
+                int scaleDiv = divisions > 0      ? divisions      : 1;
 
                 var timeEl = measureEl.Descendants(ns + "time").FirstOrDefault();
                 if (timeEl != null)
@@ -148,7 +157,7 @@ public sealed class MxlScore
                     Number               = measureNo,
                     TimeSig              = currentTimeSig,
                     KeySig               = currentKeySig,
-                    Divisions            = divisions,
+                    Divisions            = canonicalDivs > 0 ? canonicalDivs : divisions,
                     GlobalOnsetDivisions = globalOnset,
                     GlobalOnsetMs        = globalOnsetMs,
                     TimeSigBeats         = currentTSBeats,
@@ -239,8 +248,8 @@ public sealed class MxlScore
                         Octave         = octave,
                         Accidental     = accidental,
                         PitchAlter     = pitchAlter,
-                        Duration       = dur,
-                        OnsetDivisions = onset,
+                        Duration       = (int)((long)dur   * scaleMul / scaleDiv),
+                        OnsetDivisions = (int)((long)onset * scaleMul / scaleDiv),
                         NoteType       = child.Element(ns + "type")?.Value ?? string.Empty,
                         Dots           = child.Elements(ns + "dot").Count(),
                         Staff          = int.TryParse(child.Element(ns + "staff")?.Value, out var st) ? st : 1,
@@ -261,11 +270,31 @@ public sealed class MxlScore
                     .Select(n => n.OnsetDivisions + n.Duration)
                     .DefaultIfEmpty(0)
                     .Max();
-                globalOnset += rawMeasureDur;
 
-                double msPerDiv     = 60_000.0 / (120.0 * divisions);
+                int canonDivisions = canonicalDivs > 0 ? canonicalDivs : divisions;
+                double msPerDiv     = 60_000.0 / (120.0 * canonDivisions);
                 double quarterNotes = currentTSBeats * (4.0 / currentTSBeatType);
-                double expectedDivs = quarterNotes * divisions;
+                double expectedDivs = quarterNotes * canonDivisions;
+
+                if (MxlMidiPlayer.TimingDiagnostics)
+                {
+                    string tag = rawMeasureDur == (int)expectedDivs ? string.Empty
+                        : rawMeasureDur > (int)expectedDivs ? "  [OVERCOUNT]"
+                        : rawMeasureDur == 0                ? "  [EMPTY]"
+                        :                                     "  [SHORT]";
+                    Trace.WriteLine(
+                        $"PARSE m={measureNo,4}  ts={currentTimeSig,-5}  divs={canonDivisions,4}" +
+                        $"  globalOnset={globalOnset,8}  raw={rawMeasureDur,6}  expected={(int)expectedDivs,6}{tag}");
+                }
+
+                // Cap advancement at expectedDivs (same logic applied to globalOnsetMs).
+                // Overcounting happens when multi-voice backup/forward pushes the cursor beyond
+                // one measure; without capping every subsequent GlobalOnsetDivisions is wrong.
+                int advanceDivs = rawMeasureDur > 0
+                    ? Math.Min(rawMeasureDur, (int)expectedDivs)
+                    : (int)expectedDivs;
+                globalOnset += advanceDivs;
+
                 double actualMs     = expectedDivs * msPerDiv;
                 double noteBasedMs  = rawMeasureDur * msPerDiv;
                 globalOnsetMs += Math.Min(actualMs, noteBasedMs > 0 ? noteBasedMs : actualMs);
@@ -658,6 +687,12 @@ public sealed class MxlMidiPlayer : IDisposable
     /// <summary>WinMM output device index (-1 = MIDI Mapper). Ignored for FluidSynth.</summary>
     public int    WinmmDeviceId { get; set; } = -1;
     /// <summary>
+    /// When true, emits Trace lines for:
+    /// - per-measure GlobalOnsetDivisions / rawMeasureDur vs expectedDivs (parse-time)
+    /// - non-monotonic GlobalDivisions jumps in the sorted NoteOn event list
+    /// </summary>
+    public static bool TimingDiagnostics { get; set; } = false;
+    /// <summary>
     /// Staff numbers (1 = RH/green, 2 = LH/blue) whose NoteOn messages are suppressed.
     /// Checked dynamically at dispatch time — toggle at any point during playback.
     /// Mirrors <see cref="VerticalPianoRollCanvas.MutedStaves"/> so both canvas and audio
@@ -723,17 +758,33 @@ public sealed class MxlMidiPlayer : IDisposable
                 int    divs           = Math.Max(1, measure.Divisions);
                 double msPerDiv       = 60_000.0 / (Bpm * divs);
                 double measureStartMs = measure.GlobalOnsetMs * bpmScale;
+                // Cap note onsets at the measure's expected duration (timesig).
+                // Without this cap, multi-voice <backup> can push OnsetDivisions beyond the
+                // measure boundary, producing a globalDivs value that is one or more measures
+                // ahead of what the SyncAnchor predictor expects, causing visible jumps.
+                int    measureDurCap  = divs * measure.TimeSigBeats;
                 int    maxOnsetDivs   = measure.Notes
                     .Where(n => !n.IsChord)
                     .Select(n => n.OnsetDivisions + n.Duration)
-                    .DefaultIfEmpty(divs * measure.TimeSigBeats)
+                    .DefaultIfEmpty(measureDurCap)
                     .Max();
+
+                if (TimingDiagnostics && pi == 0)
+                {
+                    string tag = maxOnsetDivs > measureDurCap ? "  [OVERCOUNT]"
+                               : maxOnsetDivs == 0            ? "  [EMPTY]"
+                               :                                string.Empty;
+                    if (tag.Length > 0)
+                        Trace.WriteLine(
+                            $"MEASURE m={measure.Number,4}  ts={measure.TimeSig,-5}  divs={divs,4}" +
+                            $"  globalOnset={measure.GlobalOnsetDivisions,8}  raw={maxOnsetDivs,6}  cap={measureDurCap,6}{tag}");
+                }
 
                 foreach (var note in measure.Notes)
                 {
                     if (note.IsRest || note.MidiPitch < 21 || note.MidiPitch > 108) continue;
                     int midi = note.MidiPitch;
-                    int clampedOnset = Math.Min(note.OnsetDivisions, maxOnsetDivs - 1);
+                    int clampedOnset = Math.Min(note.OnsetDivisions, Math.Min(maxOnsetDivs, measureDurCap) - 1);
                     long globalDivs  = measure.GlobalOnsetDivisions + clampedOnset;
                     long onsetMs     = (long)(measureStartMs + clampedOnset * msPerDiv);
                     long offMs       = onsetMs + Math.Max(30, Math.Min(4_000, (long)(note.Duration * msPerDiv) - 15));
@@ -751,6 +802,45 @@ public sealed class MxlMidiPlayer : IDisposable
             .Select(g => g.First())
             .OrderBy(e => e.TimeMs)
             .ToList();
+
+        if (TimingDiagnostics)
+        {
+            // Dump every measure's globalOnset so we can spot gaps.
+            if (_score.Parts.Count > 0)
+            {
+                long prevOnset = -1; long prevActualAdvance = 0;
+                foreach (var m in _score.Parts[0].Measures)
+                {
+                    int d = Math.Max(1, m.Divisions);
+                    int cap = d * m.TimeSigBeats;
+                    // Compute the actual advance used for this measure (same logic as parser).
+                    int raw = m.Notes.Where(n => !n.IsChord)
+                        .Select(n => n.OnsetDivisions + n.Duration).DefaultIfEmpty(0).Max();
+                    int actualAdvance = raw > 0 ? Math.Min(raw, cap) : cap;
+                    long gap = prevOnset < 0 ? 0 : m.GlobalOnsetDivisions - (prevOnset + prevActualAdvance);
+                    // Only flag positive gaps (missing beats) — negative gaps are pickup bars, which are expected.
+                    string gapTag = gap > 0 ? $"  [GAP=+{gap}]" : string.Empty;
+                    Trace.WriteLine(
+                        $"MMAP m={m.Number,4}  globalOnset={m.GlobalOnsetDivisions,8}  cap={cap,6}" +
+                        $"  timeSig={m.TimeSig,-5}{gapTag}");
+                    prevOnset = m.GlobalOnsetDivisions;
+                    prevActualAdvance = actualAdvance;
+                }
+            }
+
+            // Detect any forward jump (gap) or backward jump in the sorted NoteOn event list.
+            long prevDivs = long.MinValue; long prevMs = 0;
+            foreach (var ev in events)
+            {
+                if (ev.GlobalDivisions <= 0) continue;  // NoteOff (-1) or ProgChg (0)
+                if (ev.GlobalDivisions < prevDivs)
+                    Trace.WriteLine(
+                        $"NON-MONOTONIC GlobalDivisions: m={ev.MeasureNo}  prev={prevDivs}  cur={ev.GlobalDivisions}" +
+                        $"  timeMs={ev.TimeMs}  drop={(ev.GlobalDivisions - prevDivs)}");
+                prevDivs = ev.GlobalDivisions;
+                prevMs = ev.TimeMs;
+            }
+        }
 
         long seekDivs = 0;
         long seekMs   = 0;
@@ -1692,6 +1782,7 @@ public static class VerticalPianoRollWindowFactory
         bool syncDiagnostics = false)
     {
         VerticalPianoRollCanvas.SyncDiagnostics = syncDiagnostics;
+        MxlMidiPlayer.TimingDiagnostics         = syncDiagnostics;
         var canvas      = new VerticalPianoRollCanvas(score);
         var staffCanvas = new StaffNotationCanvas(score);
         var statusBlock = new TextBlock

--- a/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
+++ b/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
@@ -1048,6 +1048,27 @@ public sealed class VerticalPianoRollCanvas : Control
     private readonly int _divsPerQuarter;
     private int    _syncCallCount;
 
+    // ── cached render resources (allocated once in ctor; reused every frame) ─────────
+    private readonly SolidColorBrush    _bgBrush;
+    private readonly SolidColorBrush    _labelBrush;
+    private readonly SolidColorBrush    _whiteKeyBrush;
+    private readonly SolidColorBrush    _blackKeyBrush;
+    private readonly SolidColorBrush    _keyLabelBrush;
+    private readonly SolidColorBrush    _edgeBrush;
+    private readonly SolidColorBrush    _activeS1;
+    private readonly SolidColorBrush    _activeS2;
+    private readonly Pen                _lanePen;
+    private readonly Pen                _cPen;
+    private readonly Pen                _whiteKeyPen;
+    private readonly Typeface           _consolasTf;
+    // Per-alpha note brushes: index = alpha byte (0–255); pre-built for all 256 values.
+    private readonly SolidColorBrush[]  _noteBrushS1 = new SolidColorBrush[256];
+    private readonly SolidColorBrush[]  _noteBrushS2 = new SolidColorBrush[256];
+    private readonly SolidColorBrush[]  _noteBrushOt = new SolidColorBrush[256];
+    // C-octave label FormattedText cache; index = octave number (0–9).
+    private readonly FormattedText?[]   _cLabelFtScroll = new FormattedText?[10];
+    private readonly FormattedText?[]   _cLabelFtKeys   = new FormattedText?[10];
+
     /// <summary>
     /// Set to true to emit Trace lines for every SyncAnchor call.
     /// Format:  SyncAnchor  #{n}  audio={divs}  predicted={p:F0}  err={errMs:+0.0;-0.0} ms  [{action}]
@@ -1143,6 +1164,39 @@ public sealed class VerticalPianoRollCanvas : Control
 
         BuildBars();
 
+        // Initialise cached render resources (avoids per-frame heap allocations)
+        const byte S1R = 64,  S1G = 200, S1B = 90;
+        const byte S2R = 80,  S2G = 130, S2B = 230;
+        const byte OtR = 200, OtG = 180, OtB = 80;
+        _bgBrush       = new SolidColorBrush(Color.FromRgb(20, 20, 20));
+        _labelBrush    = new SolidColorBrush(Color.FromArgb(120, 200, 200, 200));
+        _whiteKeyBrush = new SolidColorBrush(Color.FromRgb(240, 240, 240));
+        _blackKeyBrush = new SolidColorBrush(Color.FromRgb(30, 30, 30));
+        _keyLabelBrush = new SolidColorBrush(Color.FromRgb(100, 100, 100));
+        _edgeBrush     = new SolidColorBrush(Color.FromArgb(200, 255, 255, 255));
+        _activeS1      = new SolidColorBrush(Color.FromArgb(230, 64, 200, 90));
+        _activeS2      = new SolidColorBrush(Color.FromArgb(230, 80, 130, 230));
+        _lanePen       = new Pen(new SolidColorBrush(Color.FromArgb(30, 200, 200, 200)), 0.5);
+        _cPen          = new Pen(new SolidColorBrush(Color.FromArgb(60, 200, 200, 200)), 0.8);
+        _whiteKeyPen   = new Pen(new SolidColorBrush(Color.FromRgb(80, 80, 80)), 0.5);
+        _consolasTf    = new Typeface("Consolas");
+        for (int a = 0; a < 256; a++)
+        {
+            _noteBrushS1[a] = new SolidColorBrush(Color.FromArgb((byte)a, S1R, S1G, S1B));
+            _noteBrushS2[a] = new SolidColorBrush(Color.FromArgb((byte)a, S2R, S2G, S2B));
+            _noteBrushOt[a] = new SolidColorBrush(Color.FromArgb((byte)a, OtR, OtG, OtB));
+        }
+        for (int m = MinMidi; m <= MaxMidi; m++)
+        {
+            if (m % 12 != 0) continue;
+            int oct = m / 12 - 1;
+            if (oct < 0 || oct >= _cLabelFtScroll.Length) continue;
+            _cLabelFtScroll[oct] = new FormattedText($"C{oct}", CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight, _consolasTf, 7, _labelBrush);
+            _cLabelFtKeys[oct]   = new FormattedText($"C{oct}", CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight, _consolasTf, 7, _keyLabelBrush);
+        }
+
         _animTimer = new DispatcherTimer(DispatcherPriority.Render)
         {
             Interval = TimeSpan.FromMilliseconds(16)   // ~60 fps
@@ -1208,13 +1262,12 @@ public sealed class VerticalPianoRollCanvas : Control
             : (_currentGlobalDivisions >= 0 ? (double)_currentGlobalDivisions : 0.0))
             + latencyDiv;
 
-        ctx.FillRectangle(new SolidColorBrush(Color.FromRgb(20, 20, 20)),
-            new Rect(0, 0, _canvasW, scrollH));
+        ctx.FillRectangle(_bgBrush, new Rect(0, 0, _canvasW, scrollH));
 
-        var lanePen    = new Pen(new SolidColorBrush(Color.FromArgb(30, 200, 200, 200)), 0.5);
-        var cPen       = new Pen(new SolidColorBrush(Color.FromArgb(60, 200, 200, 200)), 0.8);
-        var labelBrush = new SolidColorBrush(Color.FromArgb(120, 200, 200, 200));
-        var tf         = new Typeface("Consolas");
+        var lanePen    = _lanePen;
+        var cPen       = _cPen;
+        var labelBrush = _labelBrush;
+        var tf         = _consolasTf;
 
         for (int m = MinMidi; m <= MaxMidi; m++)
         {
@@ -1224,16 +1277,11 @@ public sealed class VerticalPianoRollCanvas : Control
             ctx.DrawLine(pen, new Point(x, 0), new Point(x, scrollH));
             if (m % 12 == 0)
             {
-                var ft = new FormattedText($"C{m / 12 - 1}", CultureInfo.InvariantCulture,
-                    FlowDirection.LeftToRight, tf, 7, labelBrush);
-                ctx.DrawText(ft, new Point(x + 2, 2));
+                int oct = m / 12 - 1;
+                var ft = (oct >= 0 && oct < _cLabelFtScroll.Length) ? _cLabelFtScroll[oct] : null;
+                if (ft != null) ctx.DrawText(ft, new Point(x + 2, 2));
             }
         }
-
-        // Base RGB values for each staff; alpha is scaled by velocity below.
-        const byte S1R = 64,  S1G = 200, S1B = 90;   // green  – right hand
-        const byte S2R = 80,  S2G = 130, S2B = 230;  // blue   – left hand
-        const byte OtR = 200, OtG = 180, OtB = 80;   // yellow – other
 
         double divsPerSec    = bpm / 60.0 * _divsPerQuarter;
         double lookaheadDivs = divsPerSec * LookaheadSec;
@@ -1255,15 +1303,14 @@ public sealed class VerticalPianoRollCanvas : Control
             double halfW = bar.W / 2.0;
             double bx, bw;
             ISolidColorBrush brush;
-            if (bar.Staff == 1)      { bx = fullX;         bw = halfW; brush = new SolidColorBrush(Color.FromArgb(alpha, S1R, S1G, S1B)); }
-            else if (bar.Staff == 2) { bx = fullX + halfW; bw = halfW; brush = new SolidColorBrush(Color.FromArgb(alpha, S2R, S2G, S2B)); }
-            else                     { bx = fullX;         bw = bar.W; brush = new SolidColorBrush(Color.FromArgb(alpha, OtR, OtG, OtB)); }
+            if (bar.Staff == 1)      { bx = fullX;         bw = halfW; brush = _noteBrushS1[alpha]; }
+            else if (bar.Staff == 2) { bx = fullX + halfW; bw = halfW; brush = _noteBrushS2[alpha]; }
+            else                     { bx = fullX;         bw = bar.W; brush = _noteBrushOt[alpha]; }
 
             ctx.FillRectangle(brush, new Rect(bx, clippedTop, bw, clippedH), (float)Math.Min(3, bw / 2));
             double edgeY = Math.Min(yBottom, scrollH - 1);
             if (edgeY - clippedTop > 2)
-                ctx.FillRectangle(new SolidColorBrush(Color.FromArgb(200, 255, 255, 255)),
-                    new Rect(bx, edgeY - 2, bw, 2));
+                ctx.FillRectangle(_edgeBrush, new Rect(bx, edgeY - 2, bw, 2));
         }
 
         var activeKeys = new Dictionary<int, int>();
@@ -1281,11 +1328,11 @@ public sealed class VerticalPianoRollCanvas : Control
         }
 
         double kbY            = scrollH;
-        var whiteKeyBrush     = new SolidColorBrush(Color.FromRgb(240, 240, 240));
-        var blackKeyBrush     = new SolidColorBrush(Color.FromRgb(30, 30, 30));
-        var whiteKeyPen       = new Pen(new SolidColorBrush(Color.FromRgb(80, 80, 80)), 0.5);
-        var activeS1          = new SolidColorBrush(Color.FromArgb(230, 64, 200, 90));
-        var activeS2          = new SolidColorBrush(Color.FromArgb(230, 80, 130, 230));
+        var whiteKeyBrush     = _whiteKeyBrush;
+        var blackKeyBrush     = _blackKeyBrush;
+        var whiteKeyPen       = _whiteKeyPen;
+        var activeS1          = _activeS1;
+        var activeS2          = _activeS2;
 
         for (int m = MinMidi; m <= MaxMidi; m++)
         {
@@ -1304,10 +1351,9 @@ public sealed class VerticalPianoRollCanvas : Control
             ctx.DrawRectangle(null, whiteKeyPen, new Rect(kx, kbY, kw, KeyboardH));
             if (m % 12 == 0 && bits == 0)
             {
-                var ft = new FormattedText($"C{m / 12 - 1}", CultureInfo.InvariantCulture,
-                    FlowDirection.LeftToRight, tf, 7,
-                    new SolidColorBrush(Color.FromRgb(100, 100, 100)));
-                ctx.DrawText(ft, new Point(kx + 1, kbY + KeyboardH - 14));
+                int keyOct = m / 12 - 1;
+                var ft = (keyOct >= 0 && keyOct < _cLabelFtKeys.Length) ? _cLabelFtKeys[keyOct] : null;
+                if (ft != null) ctx.DrawText(ft, new Point(kx + 1, kbY + KeyboardH - 14));
             }
         }
 
@@ -1398,6 +1444,38 @@ public sealed class StaffNotationCanvas : Control
     private long   _anchorTimestamp;
     private double _playBpm = 120;
     private readonly DispatcherTimer _animTimer;
+
+    // ── cached render resources (allocated once in ctor; reused every frame) ─────
+    private readonly SolidColorBrush _bgBrush;
+    private readonly SolidColorBrush _inkBrush;
+    private readonly SolidColorBrush _staffClrBrush;
+    private readonly SolidColorBrush _barNumBrush;
+    private readonly SolidColorBrush _header1Brush;
+    private readonly SolidColorBrush _header2Brush;
+    private readonly SolidColorBrush _cursorBrush;
+    private readonly Pen             _inkPen;
+    private readonly Pen             _inkPen15;
+    private readonly Pen             _noteHeadPen;
+    private readonly Pen             _staffPen;
+    private readonly Pen             _barPen;
+    private readonly Pen             _cursorPen;
+    private readonly Typeface        _arialTf;
+    private readonly Typeface        _arialSemiBoldTf;
+    private readonly Typeface        _arialBoldTf;
+    private readonly Typeface        _clefTf;
+    private readonly Typeface        _sansItalicBoldTf;
+    private readonly FormattedText   _gClefFt;
+    private readonly FormattedText   _fClefFt;
+    private readonly FormattedText   _gFallbackFt;
+    private readonly FormattedText   _fFallbackFt;
+    private readonly FormattedText   _sharpFt;
+    private readonly FormattedText   _flatFt;
+    private readonly FormattedText   _naturalFt;
+    private readonly Dictionary<int, FormattedText> _measureNumFtCache = new();
+    private string?        _cachedHeader1;
+    private FormattedText? _cachedHeader1Ft;
+    private string?        _cachedHeader2;
+    private FormattedText? _cachedHeader2Ft;
 
     /// <summary>BPM used for between-event position interpolation. Set this before calling Play.</summary>
     public double PlayBpm
@@ -1491,6 +1569,33 @@ public sealed class StaffNotationCanvas : Control
         _notes.Sort((a, b) => a.GlobalOnset.CompareTo(b.GlobalOnset));
         _barlines.Sort((a, b) => a.Divs.CompareTo(b.Divs));
 
+        // Initialise cached render resources (avoids per-frame heap allocations)
+        _bgBrush          = new SolidColorBrush(Color.FromRgb(250, 248, 240));
+        _inkBrush         = new SolidColorBrush(Color.FromRgb(20, 20, 20));
+        _staffClrBrush    = new SolidColorBrush(Color.FromRgb(60, 60, 60));
+        _barNumBrush      = new SolidColorBrush(Color.FromRgb(80, 80, 80));
+        _header1Brush     = new SolidColorBrush(Color.FromRgb(40, 40, 120));
+        _header2Brush     = new SolidColorBrush(Color.FromRgb(100, 100, 180));
+        _cursorBrush      = new SolidColorBrush(Color.FromArgb(200, 220, 50, 50));
+        _inkPen           = new Pen(_inkBrush, 1.2);
+        _inkPen15         = new Pen(_inkBrush, 1.5);
+        _noteHeadPen      = new Pen(_inkBrush, 1.3);
+        _staffPen         = new Pen(_staffClrBrush, 0.9);
+        _barPen           = new Pen(_staffClrBrush, 1.4);
+        _cursorPen        = new Pen(_cursorBrush, 1.8);
+        _arialTf          = new Typeface("Arial");
+        _arialSemiBoldTf  = new Typeface("Arial", FontStyle.Normal, FontWeight.SemiBold);
+        _arialBoldTf      = new Typeface("Arial", FontStyle.Normal, FontWeight.Bold);
+        _clefTf           = new Typeface(new FontFamily("Segoe UI Symbol,Arial Unicode MS"), FontStyle.Normal, FontWeight.Regular);
+        _sansItalicBoldTf = new Typeface("sans-serif", FontStyle.Italic, FontWeight.Bold);
+        _gClefFt          = new FormattedText("\uD834\uDD1E", CultureInfo.InvariantCulture, FlowDirection.LeftToRight, _clefTf, 4 * LineSpacing * 1.6, _inkBrush);
+        _fClefFt          = new FormattedText("\uD834\uDD22", CultureInfo.InvariantCulture, FlowDirection.LeftToRight, _clefTf, 4 * LineSpacing * 0.9, _inkBrush);
+        _gFallbackFt      = new FormattedText("G", CultureInfo.InvariantCulture, FlowDirection.LeftToRight, _sansItalicBoldTf, 3 * LineSpacing, _inkBrush);
+        _fFallbackFt      = new FormattedText("F", CultureInfo.InvariantCulture, FlowDirection.LeftToRight, _sansItalicBoldTf, 2.5 * LineSpacing, _inkBrush);
+        _sharpFt          = new FormattedText("♯", CultureInfo.InvariantCulture, FlowDirection.LeftToRight, _arialBoldTf, 20, _inkBrush);
+        _flatFt           = new FormattedText("♭", CultureInfo.InvariantCulture, FlowDirection.LeftToRight, _arialBoldTf, 20, _inkBrush);
+        _naturalFt        = new FormattedText("♮", CultureInfo.InvariantCulture, FlowDirection.LeftToRight, _arialBoldTf, 20, _inkBrush);
+
         _animTimer = new DispatcherTimer(DispatcherPriority.Render)
         {
             Interval = TimeSpan.FromMilliseconds(16)   // ~60 fps
@@ -1540,26 +1645,30 @@ public sealed class StaffNotationCanvas : Control
         double DivsToX(double d) => nowX + (d - displayDivs) / lookaheadDiv * (W * (1 - CursorFrac));
 
         // ── background ────────────────────────────────────────────────────
-        ctx.FillRectangle(new SolidColorBrush(Color.FromRgb(250, 248, 240)), new Rect(0, 0, W, H));
+        ctx.FillRectangle(_bgBrush, new Rect(0, 0, W, H));
 
         // ── header overlay (playlist / pattern title) ─────────────────────
         double headerY = 6.0;
         if (!string.IsNullOrEmpty(HeaderLine1))
         {
-            var ft1 = new FormattedText(HeaderLine1, CultureInfo.InvariantCulture,
-                FlowDirection.LeftToRight,
-                new Typeface("Arial", FontStyle.Normal, FontWeight.SemiBold), 16,
-                new SolidColorBrush(Color.FromRgb(40, 40, 120)));
-            ctx.DrawText(ft1, new Point(ClefAreaW + 8, headerY));
-            headerY += ft1.Height + 2;
+            if (_cachedHeader1 != HeaderLine1 || _cachedHeader1Ft == null)
+            {
+                _cachedHeader1   = HeaderLine1;
+                _cachedHeader1Ft = new FormattedText(HeaderLine1, CultureInfo.InvariantCulture,
+                    FlowDirection.LeftToRight, _arialSemiBoldTf, 16, _header1Brush);
+            }
+            ctx.DrawText(_cachedHeader1Ft, new Point(ClefAreaW + 8, headerY));
+            headerY += _cachedHeader1Ft.Height + 2;
         }
         if (!string.IsNullOrEmpty(HeaderLine2))
         {
-            var ft2 = new FormattedText(HeaderLine2, CultureInfo.InvariantCulture,
-                FlowDirection.LeftToRight,
-                new Typeface("Arial", FontStyle.Normal, FontWeight.Normal), 12,
-                new SolidColorBrush(Color.FromRgb(100, 100, 180)));
-            ctx.DrawText(ft2, new Point(ClefAreaW + 8, headerY));
+            if (_cachedHeader2 != HeaderLine2 || _cachedHeader2Ft == null)
+            {
+                _cachedHeader2   = HeaderLine2;
+                _cachedHeader2Ft = new FormattedText(HeaderLine2, CultureInfo.InvariantCulture,
+                    FlowDirection.LeftToRight, _arialTf, 12, _header2Brush);
+            }
+            ctx.DrawText(_cachedHeader2Ft, new Point(ClefAreaW + 8, headerY));
         }
 
         // ── staff layout ──────────────────────────────────────────────────
@@ -1587,12 +1696,12 @@ public sealed class StaffNotationCanvas : Control
         int BassTopRow   = BassMiddleRow   + 4;
         int BassBotRow   = BassMiddleRow   - 4;
 
-        var inkBrush  = new SolidColorBrush(Color.FromRgb(20, 20, 20));
-        var inkPen    = new Pen(inkBrush, 1.2);
-        var staffPen  = new Pen(new SolidColorBrush(Color.FromRgb(60, 60, 60)), 0.9);
-        var barPen    = new Pen(new SolidColorBrush(Color.FromRgb(60, 60, 60)), 1.4);
-        var cursorPen = new Pen(new SolidColorBrush(Color.FromArgb(200, 220, 50, 50)), 1.8);
-        var tf        = new Typeface("Arial");
+        var inkBrush  = _inkBrush;
+        var inkPen    = _inkPen;
+        var staffPen  = _staffPen;
+        var barPen    = _barPen;
+        var cursorPen = _cursorPen;
+        var tf        = _arialTf;
 
         // ── draw five staff lines ──────────────────────────────────────────
         void DrawStaffLines(double topY)
@@ -1615,47 +1724,23 @@ public sealed class StaffNotationCanvas : Control
         bool useGlyphs = OperatingSystem.IsWindows();
         if (useGlyphs)
         {
-            // U+1D11E / U+1D122 are supplementary-plane chars (surrogate pairs in C#).
-            var clefTf = new Typeface(new FontFamily("Segoe UI Symbol,Arial Unicode MS"),
-                                      FontStyle.Normal, FontWeight.Regular);
-            // Treble
-            {
-                string gClef = "\uD834\uDD1E";   // U+1D11E MUSICAL SYMBOL G CLEF
-                var ft = new FormattedText(gClef, CultureInfo.InvariantCulture,
-                             FlowDirection.LeftToRight, clefTf, 4 * LineSpacing * 1.6, inkBrush);
-                ctx.DrawText(ft, new Point(2, g4Y - ft.Height * 0.72));
-            }
-            // Bass
-            {
-                string fClef = "\uD834\uDD22";   // U+1D122 MUSICAL SYMBOL F CLEF
-                var ft = new FormattedText(fClef, CultureInfo.InvariantCulture,
-                             FlowDirection.LeftToRight, clefTf, 4 * LineSpacing * 0.9, inkBrush);
-                ctx.DrawText(ft, new Point(2, f3Y - ft.Height * 0.38));
-            }
+            // Treble (U+1D11E) and Bass (U+1D122) — FormattedText cached in ctor.
+            ctx.DrawText(_gClefFt, new Point(2, g4Y - _gClefFt.Height * 0.72));
+            ctx.DrawText(_fClefFt, new Point(2, f3Y - _fClefFt.Height * 0.38));
         }
         else
         {
             // Primitive fallback (macOS / Linux): bold text labels "G" / "F" + dot pair.
-            var clefTf  = new Typeface("sans-serif", FontStyle.Italic, FontWeight.Bold);
-            var cp      = new Pen(inkBrush, 1.5);
             // Treble: italic bold "G" centred on g4Y
-            {
-                var ft = new FormattedText("G", CultureInfo.InvariantCulture,
-                             FlowDirection.LeftToRight, clefTf, 3 * LineSpacing, inkBrush);
-                ctx.DrawText(ft, new Point(2, g4Y - ft.Height * 0.55));
-                // small descending stem below
-                ctx.DrawLine(cp, new Point(ft.Width / 2 + 2, g4Y + LineSpacing * 0.5),
-                                 new Point(ft.Width / 2 + 2, g4Y + LineSpacing * 1.5));
-            }
+            ctx.DrawText(_gFallbackFt, new Point(2, g4Y - _gFallbackFt.Height * 0.55));
+            // small descending stem below
+            ctx.DrawLine(_inkPen15, new Point(_gFallbackFt.Width / 2 + 2, g4Y + LineSpacing * 0.5),
+                                    new Point(_gFallbackFt.Width / 2 + 2, g4Y + LineSpacing * 1.5));
             // Bass: italic bold "F" + two dots
-            {
-                var ft = new FormattedText("F", CultureInfo.InvariantCulture,
-                             FlowDirection.LeftToRight, clefTf, 2.5 * LineSpacing, inkBrush);
-                ctx.DrawText(ft, new Point(2, f3Y - ft.Height * 0.45));
-                double dotX = ft.Width + 6;
-                ctx.DrawEllipse(inkBrush, null, new Point(dotX, f3Y - LineSpacing * 0.55), 2.0, 2.0);
-                ctx.DrawEllipse(inkBrush, null, new Point(dotX, f3Y + LineSpacing * 0.25), 2.0, 2.0);
-            }
+            ctx.DrawText(_fFallbackFt, new Point(2, f3Y - _fFallbackFt.Height * 0.45));
+            double dotX = _fFallbackFt.Width + 6;
+            ctx.DrawEllipse(_inkBrush, null, new Point(dotX, f3Y - LineSpacing * 0.55), 2.0, 2.0);
+            ctx.DrawEllipse(_inkBrush, null, new Point(dotX, f3Y + LineSpacing * 0.25), 2.0, 2.0);
         }
 
         // ── barlines ──────────────────────────────────────────────────────
@@ -1669,9 +1754,9 @@ public sealed class StaffNotationCanvas : Control
             // measure number above treble staff
             if (bn >= 1)
             {
-                var ft = new FormattedText($"{bn}", CultureInfo.InvariantCulture,
-                    FlowDirection.LeftToRight, tf, 11,
-                    new SolidColorBrush(Color.FromRgb(80, 80, 80)));
+                if (!_measureNumFtCache.TryGetValue(bn, out var ft))
+                    _measureNumFtCache[bn] = ft = new FormattedText($"{bn}", CultureInfo.InvariantCulture,
+                        FlowDirection.LeftToRight, _arialTf, 11, _barNumBrush);
                 ctx.DrawText(ft, new Point(bx + 2, trebleTopY - LineSpacing - 2));
             }
         }
@@ -1695,8 +1780,8 @@ public sealed class StaffNotationCanvas : Control
 
             // Filled vs open head: whole/half = open; quarter/eighth/16th = filled
             bool isOpen = n.NoteType is "whole" or "half";
-            var noteBrush = isOpen ? (IBrush)new SolidColorBrush(Colors.Transparent) : inkBrush;
-            var noteHeadPen = new Pen(inkBrush, 1.3);
+            var noteBrush = isOpen ? (IBrush)Brushes.Transparent : _inkBrush;
+            var noteHeadPen = _noteHeadPen;
 
             ctx.DrawEllipse(noteBrush, noteHeadPen, new Point(x, y), NoteRadiusX, NoteRadiusY);
 
@@ -1715,10 +1800,10 @@ public sealed class StaffNotationCanvas : Control
                     double fx = stemX;
                     double fy = stemY1;
                     double flagDir = stemUp ? 1 : -1;
-                    ctx.DrawLine(new Pen(inkBrush, 1.5),
+                    ctx.DrawLine(_inkPen15,
                         new Point(fx, fy),
                         new Point(fx + 8,  fy + flagDir * 8));
-                    ctx.DrawLine(new Pen(inkBrush, 1.5),
+                    ctx.DrawLine(_inkPen15,
                         new Point(fx + 8,  fy + flagDir * 8),
                         new Point(fx + 2,  fy + flagDir * 14));
                 }
@@ -1731,10 +1816,10 @@ public sealed class StaffNotationCanvas : Control
                     for (int fi = 0; fi < 2; fi++)
                     {
                         double fyo = fy + flagDir * fi * 6;
-                        ctx.DrawLine(new Pen(inkBrush, 1.5),
+                        ctx.DrawLine(_inkPen15,
                             new Point(fx, fyo),
                             new Point(fx + 8, fyo + flagDir * 8));
-                        ctx.DrawLine(new Pen(inkBrush, 1.5),
+                        ctx.DrawLine(_inkPen15,
                             new Point(fx + 8, fyo + flagDir * 8),
                             new Point(fx + 2, fyo + flagDir * 14));
                     }
@@ -1770,9 +1855,7 @@ public sealed class StaffNotationCanvas : Control
                 };
                 if (sym.Length > 0)
                 {
-                    var accTf = new Typeface("Arial", FontStyle.Normal, FontWeight.Bold);
-                    var ft = new FormattedText(sym, CultureInfo.InvariantCulture,
-                        FlowDirection.LeftToRight, accTf, 20, inkBrush);
+                    var ft = sym == "♯" ? _sharpFt : sym == "♭" ? _flatFt : _naturalFt;
                     // Place the glyph immediately left of the notehead, vertically centred on y.
                     // ft.Height is the full bounding-box height; musical symbols have their
                     // visual centre at ~55 % from the top, so offset by 0.55 * ft.Height.
@@ -1804,7 +1887,7 @@ public sealed class StaffNotationCanvas : Control
                     break;
                 case "quarter":
                 {
-                    var rp = new Pen(inkBrush, 1.5);
+                    var rp = _inkPen15;
                     ctx.DrawLine(rp, new Point(rx + 2, rMidY - 7), new Point(rx + 6, rMidY - 2));
                     ctx.DrawLine(rp, new Point(rx + 6, rMidY - 2), new Point(rx - 2, rMidY + 3));
                     ctx.DrawLine(rp, new Point(rx - 2, rMidY + 3), new Point(rx + 3, rMidY + 9));
@@ -1813,7 +1896,7 @@ public sealed class StaffNotationCanvas : Control
                 }
                 default:
                 {
-                    var rp = new Pen(inkBrush, 1.5);
+                    var rp = _inkPen15;
                     ctx.DrawLine(rp, new Point(rx + 3, rMidY - 6), new Point(rx - 2, rMidY + 4));
                     ctx.DrawEllipse(inkBrush, null, new Point(rx + 3, rMidY - 6), 2.5, 2.5);
                     break;

--- a/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
+++ b/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
@@ -2644,7 +2644,57 @@ public static class VerticalPianoRollWindowFactory
         if (songs.Count == 0)
             throw new ArgumentException("Song list must not be empty.", nameof(songs));
 
-        int currentIndex = 0;
+        // playOrder holds indices into songs[]; shuffle operates on this, not on songs[] directly.
+        var playOrder = Enumerable.Range(0, songs.Count).ToList();
+        int currentPos = 0;   // position within playOrder
+
+        // ── Repeat / Shuffle controls ─────────────────────────────────────────
+        var repeatChk = new CheckBox
+        {
+            Content = "🔁 Repeat",
+            IsChecked = false,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Margin = new Thickness(4, 0),
+            [ToolTip.TipProperty] = "Restart playlist from the beginning when the last song ends"
+        };
+        var shuffleChk = new CheckBox
+        {
+            Content = "🔀 Shuffle",
+            IsChecked = false,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Margin = new Thickness(4, 0),
+            [ToolTip.TipProperty] = "Play songs in random order"
+        };
+
+        // Re-shuffle everything after the current position when shuffle is toggled on.
+        shuffleChk.IsCheckedChanged += (_, _) =>
+        {
+            if (shuffleChk.IsChecked == true)
+            {
+                var rng = new Random();
+                for (int i = playOrder.Count - 1; i > currentPos; i--)
+                {
+                    int j = rng.Next(currentPos + 1, i + 1);
+                    (playOrder[i], playOrder[j]) = (playOrder[j], playOrder[i]);
+                }
+            }
+            else
+            {
+                // Restore sequential order, keeping current song in place.
+                int currentSong = playOrder[currentPos];
+                playOrder = Enumerable.Range(0, songs.Count).ToList();
+                // Move the current song to currentPos so the next song is the natural successor.
+                playOrder.Remove(currentSong);
+                playOrder.Insert(currentPos, currentSong);
+            }
+        };
+
+        var leadingPanel = new StackPanel
+        {
+            Orientation = Avalonia.Layout.Orientation.Horizontal,
+        };
+        leadingPanel.Children.Add(repeatChk);
+        leadingPanel.Children.Add(shuffleChk);
 
         var player = new PianoRollPlayerControl(new PianoRollOptions
         {
@@ -2652,33 +2702,42 @@ public static class VerticalPianoRollWindowFactory
             ShowLogNotes      = false,
             ShowSkipButton    = true,
             AutoCloseOnEnd    = false,
+            LeadingControl    = leadingPanel,
         });
 
         void UpdateHeader()
         {
-            string now  = songs[currentIndex].title;
-            string next = currentIndex + 1 < songs.Count
-                ? $"Next: {songs[currentIndex + 1].title}"
-                : "Last song";
+            int songIdx  = playOrder[currentPos];
+            string progress = $"{currentPos + 1}/{songs.Count}";
+            string now  = $"[{progress}]  {songs[songIdx].title}";
+            int nextPos = currentPos + 1;
+            string next;
+            if (nextPos < playOrder.Count)
+                next = $"Next: {songs[playOrder[nextPos]].title}";
+            else if (repeatChk.IsChecked == true)
+                next = $"Next: {songs[playOrder[0]].title}  (repeating)";
+            else
+                next = "Last song";
             player.SetHeaderText(now, next);
         }
 
-        void LoadSong(int index)
+        void LoadSong(int pos)
         {
-            if (index < 0 || index >= songs.Count) return;
-            currentIndex = index;
+            if (pos < 0 || pos >= songs.Count) return;
+            currentPos = pos;
+            int songIdx = playOrder[pos];
 
             try
             {
-                string xmlPath = ResolveMxlToXml(songs[index].mxlPath);
+                string xmlPath = ResolveMxlToXml(songs[songIdx].mxlPath);
                 var score      = MxlScore.Parse(File.ReadAllText(xmlPath));
                 player.LoadScore(score, autoPlay: true);
                 UpdateHeader();   // must be after LoadScore — it creates a fresh StaffNotationCanvas
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"BuildPlaylistWindow: failed to load song {index}: {ex.Message}");
-                LoadSong(index + 1);
+                Trace.WriteLine($"BuildPlaylistWindow: failed to load song at pos {pos} (songIdx {songIdx}): {ex.Message}");
+                LoadSong(pos + 1);
             }
         }
 
@@ -2686,9 +2745,22 @@ public static class VerticalPianoRollWindowFactory
         Window?[] windowRef = [null];
         player.SetSkipAction(() =>
         {
-            int next = currentIndex + 1;
+            int next = currentPos + 1;
             if (next < songs.Count)
                 LoadSong(next);
+            else if (repeatChk.IsChecked == true)
+            {
+                if (shuffleChk.IsChecked == true)
+                {
+                    var rng = new Random();
+                    for (int i = playOrder.Count - 1; i > 0; i--)
+                    {
+                        int j = rng.Next(i + 1);
+                        (playOrder[i], playOrder[j]) = (playOrder[j], playOrder[i]);
+                    }
+                }
+                LoadSong(0);
+            }
             else
                 windowRef[0]?.Close();
         });
@@ -2696,12 +2768,30 @@ public static class VerticalPianoRollWindowFactory
         // Auto-advance when a song ends (2-second pause between songs).
         player.PlaybackEnded += (_, _) =>
         {
-            int next = currentIndex + 1;
+            int next = currentPos + 1;
             if (next < songs.Count)
                 Task.Run(async () =>
                 {
                     await Task.Delay(2000).ConfigureAwait(false);
                     Dispatcher.UIThread.Post(() => LoadSong(next), DispatcherPriority.Normal);
+                });
+            else if (repeatChk.IsChecked == true)
+                Task.Run(async () =>
+                {
+                    await Task.Delay(2000).ConfigureAwait(false);
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        if (shuffleChk.IsChecked == true)
+                        {
+                            var rng = new Random();
+                            for (int i = playOrder.Count - 1; i > 0; i--)
+                            {
+                                int j = rng.Next(i + 1);
+                                (playOrder[i], playOrder[j]) = (playOrder[j], playOrder[i]);
+                            }
+                        }
+                        LoadSong(0);
+                    }, DispatcherPriority.Normal);
                 });
             else
                 Dispatcher.UIThread.Post(() => windowRef[0]?.Close(), DispatcherPriority.Normal);

--- a/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
+++ b/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
@@ -1661,7 +1661,7 @@ public sealed class StaffNotationCanvas : Control
         // ── barlines ──────────────────────────────────────────────────────
         foreach (var (bd, bn) in _barlines)
         {
-            double bx = DivsToX(bd);
+            double bx = DivsToX(bd) - 18;   // shift left so barline doesn't overlap note heads
             if (bx < ClefAreaW - 2 || bx > W) continue;
             // span each staff fully (top line to bottom line)
             ctx.DrawLine(barPen, new Point(bx, trebleTopY), new Point(bx, trebleTopY + 4 * LineSpacing));
@@ -1900,6 +1900,16 @@ public sealed class PianoRollPlayerControl : UserControl
     private List<(long Divs, int Number)> _measureDivMap = new();
     private int                      _totalMeasures = 1;
     private Window?                  _hostWindow;
+
+    // sleep prevention
+    [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint SetThreadExecutionState(uint esFlags);
+    private const uint ES_CONTINUOUS       = 0x80000000u;
+    private const uint ES_SYSTEM_REQUIRED  = 0x00000001u;
+    private const uint ES_DISPLAY_REQUIRED = 0x00000002u;
+
+    private static void PreventSleep()  => SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED);
+    private static void AllowSleep()    => SetThreadExecutionState(ES_CONTINUOUS);
 
     // debounce tokens
     private CancellationTokenSource? _bpmDebCts;
@@ -2178,6 +2188,7 @@ public sealed class PianoRollPlayerControl : UserControl
         if (sc != null) sc.CurrentGlobalDivisions = -1;
         if (_measureSlider != null) _measureSlider.Value = 1;
         _playPauseBtn.Content = "▶  Play";
+        if (_isWindows) AllowSleep();
         // Stop on a background thread, holding _midiLock so a concurrent StartPlayer
         // cannot call midiOutOpen until this midiOutClose is fully complete.
         Interlocked.Increment(ref _startGen);  // invalidate any pending StartPlayer Task
@@ -2264,6 +2275,7 @@ public sealed class PianoRollPlayerControl : UserControl
         int mno = (int)(_measureSlider?.Value ?? 1);
         _statusBlock.Text = $"Paused  |  M {mno}/{_totalMeasures}  |  BPM: {_bpmSlider.Value:F0}";
         _playPauseBtn.Content = "▶  Play";
+        if (_isWindows) AllowSleep();
         if (p != null)
             Task.Run(async () =>
             {
@@ -2299,6 +2311,7 @@ public sealed class PianoRollPlayerControl : UserControl
         };
         _player = player;
         ApplyMutes();
+        if (_isWindows) PreventSleep();
 
         long startDivs = measure <= 1
             ? 0
@@ -2680,12 +2693,16 @@ public static class VerticalPianoRollWindowFactory
                 windowRef[0]?.Close();
         });
 
-        // Auto-advance when a song ends.
+        // Auto-advance when a song ends (2-second pause between songs).
         player.PlaybackEnded += (_, _) =>
         {
             int next = currentIndex + 1;
             if (next < songs.Count)
-                Dispatcher.UIThread.Post(() => LoadSong(next), DispatcherPriority.Normal);
+                Task.Run(async () =>
+                {
+                    await Task.Delay(2000).ConfigureAwait(false);
+                    Dispatcher.UIThread.Post(() => LoadSong(next), DispatcherPriority.Normal);
+                });
             else
                 Dispatcher.UIThread.Post(() => windowRef[0]?.Close(), DispatcherPriority.Normal);
         };

--- a/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
+++ b/SheetMusicViewer.Desktop/VerticalPianoRollWindow.cs
@@ -492,12 +492,14 @@ internal sealed class WinmmMidiBackend : IMidiBackend
 
     public void Open()
     {
-        // Retry with back-off: the OS can take a short time to release the device
-        // after a previous Close(), especially when patterns switch rapidly.
-        for (int attempt = 0; attempt < 6; attempt++)
+        // Small initial yield: midiOutClose() is asynchronous inside the driver;
+        // giving the OS a moment before the first Open() attempt avoids a spurious
+        // failure when a new player is started immediately after the previous one closed.
+        Thread.Sleep(20);
+        for (int attempt = 0; attempt < 8; attempt++)
         {
             if (midiOutOpen(out _h, DeviceId, IntPtr.Zero, IntPtr.Zero, 0) == 0) return;
-            Thread.Sleep(30 * (attempt + 1));  // 30 ms, 60 ms, 90 ms …
+            Thread.Sleep(50 * (attempt + 1));  // 50 ms, 100 ms, 150 ms … up to 400 ms
         }
         throw new InvalidOperationException("Could not open MIDI output device (winmm).");
     }
@@ -786,7 +788,9 @@ public sealed class MxlMidiPlayer : IDisposable
     {
         Trace.WriteLine($"{DateTime.Now:HH:mm:ss.fff} PLAYER STOP called");
         _cts?.Cancel();
-        try { _playTask.Wait(TimeSpan.FromSeconds(2)); } catch { }
+        try { _playTask.Wait(TimeSpan.FromSeconds(5)); } catch { }
+        // PlaySync may have already closed _backend on natural end; Close() is
+        // idempotent (guarded by _h == IntPtr.Zero) so calling it again is safe.
         _backend?.Close();
         _backend = null;
         _cts = null;
@@ -967,7 +971,18 @@ public sealed class MxlMidiPlayer : IDisposable
         {
             Trace.WriteLine($"{DateTime.Now:HH:mm:ss.fff} PLAYBACK END  cancelled={ct.IsCancellationRequested}");
             if (!ct.IsCancellationRequested)
-                PlaybackEnded?.Invoke(this, EventArgs.Empty);
+            {
+                // Close the device NOW, while we are still on the play thread.
+                // This releases the WinMM handle before the next song tries to open it.
+                _backend?.Close();
+                _backend = null;
+                // Fire PlaybackEnded via Task.Run so this play task exits first.
+                // If we invoked inline here, any handler that calls Stop()->Wait()
+                // would deadlock waiting for this very task to finish.
+                var ev = PlaybackEnded;
+                if (ev != null)
+                    Task.Run(() => ev.Invoke(this, EventArgs.Empty));
+            }
         }
     }
 
@@ -1879,6 +1894,8 @@ public sealed class PianoRollPlayerControl : UserControl
     private VerticalPianoRollCanvas? _canvas;
     private MxlScore?                _currentScore;
     private MxlMidiPlayer?           _player;
+    private readonly SemaphoreSlim   _midiLock = new(1, 1);  // serialises all stop/open ops
+    private int                      _startGen;              // incremented each StartPlayer call
     private bool                     _suppressMeasureSync;
     private List<(long Divs, int Number)> _measureDivMap = new();
     private int                      _totalMeasures = 1;
@@ -2161,7 +2178,16 @@ public sealed class PianoRollPlayerControl : UserControl
         if (sc != null) sc.CurrentGlobalDivisions = -1;
         if (_measureSlider != null) _measureSlider.Value = 1;
         _playPauseBtn.Content = "▶  Play";
-        if (p != null) Task.Run(() => { try { p.Stop(); p.Dispose(); } catch { } });
+        // Stop on a background thread, holding _midiLock so a concurrent StartPlayer
+        // cannot call midiOutOpen until this midiOutClose is fully complete.
+        Interlocked.Increment(ref _startGen);  // invalidate any pending StartPlayer Task
+        if (p != null)
+            Task.Run(async () =>
+            {
+                await _midiLock.WaitAsync().ConfigureAwait(false);
+                try   { p.Stop(); p.Dispose(); } catch { }
+                finally { _midiLock.Release(); }
+            });
     }
 
     // ── private helpers ───────────────────────────────────────────────────────
@@ -2238,7 +2264,13 @@ public sealed class PianoRollPlayerControl : UserControl
         int mno = (int)(_measureSlider?.Value ?? 1);
         _statusBlock.Text = $"Paused  |  M {mno}/{_totalMeasures}  |  BPM: {_bpmSlider.Value:F0}";
         _playPauseBtn.Content = "▶  Play";
-        if (p != null) Task.Run(() => { try { p.Stop(); p.Dispose(); } catch { } });
+        if (p != null)
+            Task.Run(async () =>
+            {
+                await _midiLock.WaitAsync().ConfigureAwait(false);
+                try   { p.Stop(); p.Dispose(); } catch { }
+                finally { _midiLock.Release(); }
+            });
     }
 
     private void StartPlayer(int measure, double bpm)
@@ -2248,10 +2280,10 @@ public sealed class PianoRollPlayerControl : UserControl
         var canvas = _canvas;
         var sc = _contentGrid.Children.OfType<StaffNotationCanvas>().FirstOrDefault();
 
-        // Stop old player asynchronously
+        // Capture and clear the old player immediately so PositionChanged/PlaybackEnded
+        // callbacks from it are ignored while we are switching.
         var old = _player;
         _player = null;
-        if (old != null) Task.Run(() => { try { old.Stop(); old.Dispose(); } catch { } });
 
         bool useFluid  = _fluidChk.IsChecked == true || !_isWindows;
         string? sf     = useFluid ? VerticalPianoRollWindowFactory.FindSoundfont() : null;
@@ -2311,7 +2343,49 @@ public sealed class PianoRollPlayerControl : UserControl
 
         _statusBlock.Text = $"Playing  |  BPM: {bpm:F0}  |  {score.Title}";
         _playPauseBtn.Content = "⏸  Pause";
-        player.Start();
+
+        // Use a semaphore so that every stop+open sequence is fully serialised.
+        // Multiple rapid calls (debounce, playlist advance, pause+play) each
+        // increment the generation; any Task that is no longer the latest simply
+        // disposes the player it built and exits without calling midiOutOpen.
+        var myGen = Interlocked.Increment(ref _startGen);
+        Task.Run(async () =>
+        {
+            await _midiLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                // Stop old device — blocks until midiOutClose completes.
+                if (old != null) { try { old.Stop(); old.Dispose(); } catch { } }
+
+                // If a newer StartPlayer was called while we were waiting or stopping,
+                // discard this player — it will be started by the newer Task.
+                if (myGen != _startGen)
+                {
+                    try { player.Dispose(); } catch { }
+                    return;
+                }
+
+                // Open + start new player.
+                try
+                {
+                    player.Start();
+                }
+                catch (Exception ex)
+                {
+                    Trace.WriteLine($"PianoRollPlayerControl.StartPlayer: {ex}");
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        if (ReferenceEquals(_player, player)) _player = null;
+                        _playPauseBtn.Content = "▶  Play";
+                        _statusBlock.Text = $"MIDI error: {ex.Message}";
+                    }, DispatcherPriority.Normal);
+                }
+            }
+            finally
+            {
+                _midiLock.Release();
+            }
+        });
     }
 
     private void OnPlayPauseClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
@@ -2585,8 +2659,8 @@ public static class VerticalPianoRollWindowFactory
             {
                 string xmlPath = ResolveMxlToXml(songs[index].mxlPath);
                 var score      = MxlScore.Parse(File.ReadAllText(xmlPath));
-                UpdateHeader();
                 player.LoadScore(score, autoPlay: true);
+                UpdateHeader();   // must be after LoadScore — it creates a fresh StaffNotationCanvas
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This pull request introduces support for user-created piano-roll auto-play playlists, allowing users to create, save, and manage named lists of songs for the piano-roll "player piano" mode. It also adds comprehensive regression tests for MusicXML parsing, specifically covering divisions normalization and tied-note merging. Additionally, there are minor UI and test adjustments.

**Piano-roll playlist feature:**

* Added new data types `PianoRollPlaylist` and `PianoRollPlaylistEntry` to represent named playlists and their entries for the piano-roll auto-play mode. These store song paths and display names, and support serialization.
* Extended `UserOptionsSettings` and internal `RoamingSettings` to include `PianoRollPlaylists` and `LastSelectedPianoRollPlaylist`, ensuring these playlists roam with the music folder and persist across sessions. [[1]](diffhunk://#diff-a6298f5221d37f6f93adc5dedeab0be7d7a589057ba4102d546eebda37d41723R348-R359) [[2]](diffhunk://#diff-a6298f5221d37f6f93adc5dedeab0be7d7a589057ba4102d546eebda37d41723R838-R839)
* Updated settings load, save, and reset logic to handle the new piano-roll playlist fields, ensuring correct initialization, persistence, and clearing of playlists as needed. [[1]](diffhunk://#diff-a6298f5221d37f6f93adc5dedeab0be7d7a589057ba4102d546eebda37d41723R535-R536) [[2]](diffhunk://#diff-a6298f5221d37f6f93adc5dedeab0be7d7a589057ba4102d546eebda37d41723R551-R552) [[3]](diffhunk://#diff-a6298f5221d37f6f93adc5dedeab0be7d7a589057ba4102d546eebda37d41723L648-R666) [[4]](diffhunk://#diff-a6298f5221d37f6f93adc5dedeab0be7d7a589057ba4102d546eebda37d41723R760-R761)

**MusicXML parsing regression tests:**

* Added new test cases to validate that `GlobalOnsetDivisions` is monotonically non-decreasing, and that divisions changes within a score are correctly normalized to the canonical unit. This prevents timing errors when divisions change mid-piece.
* Added robust tests for tied-note merging both within and across measures, including chained ties across multiple measures, to ensure notes are merged and durations calculated correctly.

**Minor UI/test adjustments:**

* Updated test code in `MxlVisualizationManualTests` to use a different test file and to explicitly specify parameters for piano roll visualization. [[1]](diffhunk://#diff-bfc02a4a8790555477e6a2a8f29c5ec9fa7bcac43f2da4a6af089dfa67c8c820L45-R45) [[2]](diffhunk://#diff-bfc02a4a8790555477e6a2a8f29c5ec9fa7bcac43f2da4a6af089dfa67c8c820L214-R217)
* Reformatted slider initialization in the piano roll window for clarity (no functional change). [[1]](diffhunk://#diff-bfc02a4a8790555477e6a2a8f29c5ec9fa7bcac43f2da4a6af089dfa67c8c820L772-R775) [[2]](diffhunk://#diff-bfc02a4a8790555477e6a2a8f29c5ec9fa7bcac43f2da4a6af089dfa67c8c820L797-R801)